### PR TITLE
Feat/#9 crew create

### DIFF
--- a/src/main/java/com/example/momowas/crew/controller/CrewController.java
+++ b/src/main/java/com/example/momowas/crew/controller/CrewController.java
@@ -1,0 +1,27 @@
+package com.example.momowas.crew.controller;
+
+import com.example.momowas.crew.dto.CreateCrewReqDto;
+import com.example.momowas.crew.dto.CrewResDto;
+import com.example.momowas.crew.service.CrewService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/crews")
+public class CrewController {
+    private final CrewService crewService;
+
+    @PostMapping("")
+    @PreAuthorize("isAuthenticated()")
+    public CrewResDto createCrew(@RequestBody CreateCrewReqDto createCrewReqDto, @AuthenticationPrincipal Long userId){
+        return crewService.createCrew(createCrewReqDto, userId);
+    }
+
+}

--- a/src/main/java/com/example/momowas/crew/domain/Category.java
+++ b/src/main/java/com/example/momowas/crew/domain/Category.java
@@ -1,0 +1,18 @@
+package com.example.momowas.crew.domain;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum Category {
+    ACTIVITY("액티비티"),
+    CULTURE_ART("문화·예술"),
+    FOOD("푸드·드링크"),
+    HOBBY("취미"),
+    TRAVEL("여행"),
+    SELF_IMPROVEMENT("자기계발"),
+    FINANCE("재테크"),
+    GAMING("게임");
+
+    private final String category;
+}
+

--- a/src/main/java/com/example/momowas/crew/domain/Crew.java
+++ b/src/main/java/com/example/momowas/crew/domain/Crew.java
@@ -1,0 +1,86 @@
+package com.example.momowas.crew.domain;
+
+import com.example.momowas.crewmember.domain.CrewMember;
+import com.example.momowas.user.domain.Gender;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.util.StringUtils;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Crew {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    private Category category;
+
+    private String description;
+
+    private String descriptionImage;
+
+    private Integer minMembers;
+
+    private Integer maxMembers;
+
+    private Integer minAge; //'제한없음'은 null로 처리.
+
+    private Integer maxAge; //'제한없음'은 null로 처리.
+
+    @Enumerated(EnumType.STRING)
+    private Gender genderRestriction; //'제한없음'은 null로 처리.
+
+    private String bannerImage;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @OneToMany(mappedBy = "crew", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    private List<CrewMember> crewMembers=new ArrayList<>();
+
+    @Builder
+    private Crew(String name,
+                 Category category,
+                 String description,
+                 String descriptionImage,
+                 Integer minMembers,
+                 Integer maxMembers,
+                 Integer minAge,
+                 Integer maxAge,
+                 Gender genderRestriction,
+                 String bannerImage,
+                 LocalDateTime createdAt
+    ) {
+        if (!StringUtils.hasText(name)) {
+            throw new IllegalArgumentException("name은 null이거나 빈 문자열이 될 수 없습니다.");
+        }else if(!StringUtils.hasText(description)) {
+            throw new IllegalArgumentException("description은 null이거나 빈 문자열이 될 수 없습니다.");
+        }
+
+        this.name=name;
+        this.category= Objects.requireNonNull(category, "category는 null이 될 수 없습니다.");
+        this.description=description;
+        this.descriptionImage=descriptionImage;
+        this.minMembers=Objects.requireNonNull(minMembers, "minMembers는 null이 될 수 없습니다.");
+        this.maxMembers=Objects.requireNonNull(maxMembers, "maxMembers는 null이 될 수 없습니다.");
+        this.minAge=minAge;
+        this.maxAge=maxAge;
+        this.genderRestriction=genderRestriction;
+        this.bannerImage=bannerImage;
+        this.createdAt=Objects.requireNonNull(createdAt, "createdAt는 null이 될 수 없습니다.");
+    }
+
+}

--- a/src/main/java/com/example/momowas/crew/domain/Role.java
+++ b/src/main/java/com/example/momowas/crew/domain/Role.java
@@ -1,0 +1,7 @@
+package com.example.momowas.crew.domain;
+
+public enum Role {
+    LEADER,
+    MEMBER;
+    //더 추가 필요
+}

--- a/src/main/java/com/example/momowas/crew/dto/CreateCrewReqDto.java
+++ b/src/main/java/com/example/momowas/crew/dto/CreateCrewReqDto.java
@@ -1,0 +1,39 @@
+package com.example.momowas.crew.dto;
+
+import com.example.momowas.crew.domain.Category;
+import com.example.momowas.crew.domain.Crew;
+import com.example.momowas.region.dto.RegionReqDto;
+import com.example.momowas.user.domain.Gender;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record CreateCrewReqDto(
+        String name,
+        Category category,
+        String description,
+        String descriptionImage,
+        Integer minMembers,
+        Integer maxMembers,
+        Integer minAge,
+        Integer maxAge,
+        Gender genderRestriction,
+        String bannerImage,
+        List<RegionReqDto> regions
+){
+    public Crew toEntity() {
+        return Crew.builder()
+                .name(name)
+                .category(category)
+                .description(description)
+                .descriptionImage(descriptionImage)
+                .minMembers(minMembers)
+                .maxMembers(maxMembers)
+                .minAge(minAge)
+                .maxAge(maxAge)
+                .genderRestriction(genderRestriction)
+                .bannerImage(bannerImage)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/main/java/com/example/momowas/crew/dto/CrewResDto.java
+++ b/src/main/java/com/example/momowas/crew/dto/CrewResDto.java
@@ -1,0 +1,11 @@
+package com.example.momowas.crew.dto;
+
+import com.example.momowas.crew.domain.Crew;
+
+import java.time.LocalDateTime;
+
+public record CrewResDto(Long crewId, String name, LocalDateTime createdAt) {
+    public static CrewResDto fromEntity(Crew crew) {
+        return new CrewResDto(crew.getId(), crew.getName(), crew.getCreatedAt());
+    }
+}

--- a/src/main/java/com/example/momowas/crew/repository/CrewRepository.java
+++ b/src/main/java/com/example/momowas/crew/repository/CrewRepository.java
@@ -1,0 +1,10 @@
+package com.example.momowas.crew.repository;
+
+import com.example.momowas.crew.domain.Crew;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CrewRepository extends JpaRepository<Crew, Long> {
+    boolean existsByName(String name);
+}

--- a/src/main/java/com/example/momowas/crew/service/CrewService.java
+++ b/src/main/java/com/example/momowas/crew/service/CrewService.java
@@ -1,0 +1,42 @@
+package com.example.momowas.crew.service;
+
+import com.example.momowas.crew.domain.Crew;
+import com.example.momowas.crew.dto.CreateCrewReqDto;
+import com.example.momowas.crew.dto.CrewResDto;
+import com.example.momowas.crew.repository.CrewRepository;
+import com.example.momowas.crewmember.service.CrewMemberService;
+import com.example.momowas.crewregion.service.CrewRegionService;
+import com.example.momowas.response.BusinessException;
+import com.example.momowas.response.ExceptionCode;
+import com.example.momowas.user.domain.User;
+import com.example.momowas.user.service.UserService;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CrewService {
+    private final CrewRepository crewRepository;
+    private final CrewMemberService crewMemberService;
+    private final CrewRegionService crewRegionService;
+    private final UserService userService;
+
+    /* 크루 생성 */
+    @Transactional
+    public CrewResDto createCrew(CreateCrewReqDto createCrewReqDto, Long userId) {
+
+        //크루명 중복 검증
+        if (crewRepository.existsByName(createCrewReqDto.name())) {
+            throw new BusinessException(ExceptionCode.ALREADY_EXISTS_CREW);
+        }
+
+        Crew crew = crewRepository.save(createCrewReqDto.toEntity()); //크루 저장
+        crewRegionService.createCrewRegion(createCrewReqDto.regions(), crew); //크루-지역 저장
+
+        User user = userService.readById(userId);
+        crewMemberService.createAdmin(user, crew); //크루 멤버 저장
+
+        return CrewResDto.fromEntity(crew);
+    }
+}

--- a/src/main/java/com/example/momowas/crewmember/domain/CrewMember.java
+++ b/src/main/java/com/example/momowas/crewmember/domain/CrewMember.java
@@ -1,0 +1,51 @@
+package com.example.momowas.crewmember.domain;
+
+import com.example.momowas.crew.domain.Crew;
+import com.example.momowas.crew.domain.Role;
+import com.example.momowas.user.domain.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CrewMember {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="crew_id")
+    private Crew crew;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="user_id")
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    @CreatedDate
+    private LocalDateTime joinedAt;
+
+    @Builder
+    private CrewMember(Crew crew, User user, Role role) {
+        this.crew= Objects.requireNonNull(crew,"crew는 null이 될 수 없습니다.");
+        this.user=Objects.requireNonNull(user,"user는 null이 될 수 없습니다.");
+        this.role=Objects.requireNonNull(role,"role는 null이 될 수 없습니다.");
+    }
+
+    public static CrewMember of(Crew crew, User user, Role role) {
+        return CrewMember.builder()
+                .crew(crew)
+                .user(user)
+                .role(role)
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/momowas/crewmember/repository/CrewMemberRepository.java
+++ b/src/main/java/com/example/momowas/crewmember/repository/CrewMemberRepository.java
@@ -1,0 +1,9 @@
+package com.example.momowas.crewmember.repository;
+
+import com.example.momowas.crewmember.domain.CrewMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CrewMemberRepository extends JpaRepository<CrewMember,Long> {
+}

--- a/src/main/java/com/example/momowas/crewmember/service/CrewMemberService.java
+++ b/src/main/java/com/example/momowas/crewmember/service/CrewMemberService.java
@@ -1,0 +1,23 @@
+package com.example.momowas.crewmember.service;
+
+import com.example.momowas.crew.domain.Crew;
+import com.example.momowas.crew.domain.Role;
+import com.example.momowas.crewmember.domain.CrewMember;
+import com.example.momowas.crewmember.repository.CrewMemberRepository;
+import com.example.momowas.user.domain.User;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CrewMemberService {
+
+    private final CrewMemberRepository crewMemberRepository;
+
+    @Transactional
+    public CrewMember createAdmin(User user, Crew crew) {
+        CrewMember crewMember = CrewMember.of(crew, user, Role.LEADER);
+        return crewMemberRepository.save(crewMember);
+    }
+}

--- a/src/main/java/com/example/momowas/crewregion/domain/CrewRegion.java
+++ b/src/main/java/com/example/momowas/crewregion/domain/CrewRegion.java
@@ -1,0 +1,39 @@
+package com.example.momowas.crewregion.domain;
+
+import com.example.momowas.crew.domain.Crew;
+import com.example.momowas.region.domain.Region;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import java.util.Objects;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CrewRegion {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "region_id")
+    private Region region;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "crew_id")
+    private Crew crew;
+
+    @Builder
+    private CrewRegion(Region region, Crew crew) {
+        this.region= Objects.requireNonNull(region,"region는 null이 될 수 없습니다.");
+        this.crew=Objects.requireNonNull(crew,"crew는 null이 될 수 없습니다.");
+    }
+
+    public static CrewRegion of(Region region, Crew crew) {
+        return CrewRegion.builder()
+                .region(region)
+                .crew(crew)
+                .build();
+    }
+}

--- a/src/main/java/com/example/momowas/crewregion/repository/CrewRegionRepository.java
+++ b/src/main/java/com/example/momowas/crewregion/repository/CrewRegionRepository.java
@@ -1,0 +1,9 @@
+package com.example.momowas.crewregion.repository;
+
+import com.example.momowas.crewregion.domain.CrewRegion;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CrewRegionRepository extends JpaRepository<CrewRegion, Long> {
+}

--- a/src/main/java/com/example/momowas/crewregion/service/CrewRegionService.java
+++ b/src/main/java/com/example/momowas/crewregion/service/CrewRegionService.java
@@ -1,0 +1,33 @@
+package com.example.momowas.crewregion.service;
+
+import com.example.momowas.crew.domain.Crew;
+import com.example.momowas.crewregion.domain.CrewRegion;
+import com.example.momowas.crewregion.repository.CrewRegionRepository;
+import com.example.momowas.region.domain.Region;
+import com.example.momowas.region.dto.RegionReqDto;
+import com.example.momowas.region.service.RegionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CrewRegionService {
+    private final CrewRegionRepository crewRegionRepository;
+    private final RegionService regionService;
+
+    public void createCrewRegion(List<RegionReqDto> regionReqDtos, Crew crew) {
+
+        List<CrewRegion> crewRegions = regionReqDtos.stream()
+                .map(regionReqDto -> {
+                    Region region = regionService.findRegion(regionReqDto.regionDepth1(), regionReqDto.regionDepth2(), regionReqDto.regionDepth3());
+                    return CrewRegion.of(region, crew);
+                }).collect(Collectors.toList());
+
+        crewRegionRepository.saveAll(crewRegions);
+    }
+
+
+}

--- a/src/main/java/com/example/momowas/region/domain/Region.java
+++ b/src/main/java/com/example/momowas/region/domain/Region.java
@@ -1,0 +1,25 @@
+package com.example.momowas.region.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Region {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String regionDepth1;
+
+    private String regionDepth2;
+
+    private String regionDepth3;
+
+}

--- a/src/main/java/com/example/momowas/region/dto/RegionReqDto.java
+++ b/src/main/java/com/example/momowas/region/dto/RegionReqDto.java
@@ -1,0 +1,4 @@
+package com.example.momowas.region.dto;
+
+public record RegionReqDto(String regionDepth1, String regionDepth2, String regionDepth3) {
+}

--- a/src/main/java/com/example/momowas/region/repository/RegionRepository.java
+++ b/src/main/java/com/example/momowas/region/repository/RegionRepository.java
@@ -1,0 +1,13 @@
+package com.example.momowas.region.repository;
+
+import com.example.momowas.region.domain.Region;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RegionRepository extends JpaRepository<Region,Long> {
+    Optional<Region> findByRegionDepth1AndRegionDepth2AndRegionDepth3(String regionDepth1, String regionDepth2, String regionDepth3);
+
+}

--- a/src/main/java/com/example/momowas/region/service/RegionService.java
+++ b/src/main/java/com/example/momowas/region/service/RegionService.java
@@ -1,0 +1,20 @@
+package com.example.momowas.region.service;
+
+import com.example.momowas.region.domain.Region;
+import com.example.momowas.region.repository.RegionRepository;
+import com.example.momowas.response.BusinessException;
+import com.example.momowas.response.ExceptionCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RegionService {
+    private final RegionRepository regionRepository;
+
+    public Region findRegion(String depth1, String depth2, String depth3) {
+        return regionRepository.findByRegionDepth1AndRegionDepth2AndRegionDepth3(depth1, depth2, depth3)
+                .orElseThrow(()->new BusinessException(ExceptionCode.NOT_FOUND_REGION));
+    }
+
+}

--- a/src/main/java/com/example/momowas/response/ExceptionCode.java
+++ b/src/main/java/com/example/momowas/response/ExceptionCode.java
@@ -50,7 +50,14 @@ public enum ExceptionCode {
     EXPIRED_VERIFICATION_CODE(400, "S003", "인증 코드가 만료되었습니다."),
 
     //채팅방 예외
-    CHATROOM_NOT_FOUND(500, "C001", "채팅방을 찾을 수 없습니다.");
+    CHATROOM_NOT_FOUND(500, "C001", "채팅방을 찾을 수 없습니다."),
+
+    //크루 관련 예외
+    ALREADY_EXISTS_CREW(409, "C001", "이미 존재하는 크루입니다."),
+
+    //지역 관련 예외
+    NOT_FOUND_REGION(404, "R001", "해당 지역이 존재하지 않습니다.");
+
 
     private final int status;
     private final String code;

--- a/src/main/java/com/example/momowas/response/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/momowas/response/GlobalExceptionHandler.java
@@ -21,6 +21,19 @@ import org.springframework.web.servlet.NoHandlerFoundException;
 public class GlobalExceptionHandler {
 
     /**
+     * [Exception] 비즈니스 로직에 예외가 발생하는 경우
+     *
+     * @param ex BusinessException
+     * @return ResponseEntity<ErrorResponse>
+     */
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> handleCustomException(BusinessException ex) {
+        log.error("Business Exception Error", ex);
+        final ErrorResponse errorResponse = ErrorResponse.of(ex.getExceptionCode(), ex.getMessage());
+        return new ResponseEntity<>(errorResponse, HttpStatus.valueOf(errorResponse.getStatus()));
+    }
+
+    /**
      * [Exception] API 호출 시 '객체' 혹은 '파라미터' 데이터 값이 유효하지 않은 경우
      *
      * @param ex MethodArgumentNotValidException

--- a/src/main/java/com/example/momowas/user/service/UserService.java
+++ b/src/main/java/com/example/momowas/user/service/UserService.java
@@ -32,4 +32,8 @@ public class UserService {
     public User findUserByProviderId(String providerId){
         return userRepository.findByProviderId(providerId);
     }
+
+    public User readById(Long id) {
+        return userRepository.findById(id).orElseThrow(() -> new BusinessException(ExceptionCode.USER_NOT_FOUND));
+    }
 }


### PR DESCRIPTION
## 🔗PR 타입
- [x]  feat : 기능 추가 
- [x]  fix : 버그 수정
- [ ]  docs : 문서 관련
- [ ]  style : 스타일 변경
- [ ]  refact : 코드 리팩토링
- [ ]  build : 빌드 관련 파일 수정
- [ ]  chore : 그 외 자잘한 수정

## 🔔 변경 사항 
크루 생성 기능 구현했습니다. <br>

`크루`

UserService에 아래 메서드가 있던데 

``` java
public UserDto read(Long id) {
    User user = userRepository.findById(id).orElseThrow(() -> new BusinessException(ExceptionCode.USER_NOT_FOUND));
    return UserDto.fromEntity(user);
}
```
UserDto 말고 User가 필요해서
``` java
public User readById(Long id) {
    return userRepository.findById(id).orElseThrow(() -> new BusinessException(ExceptionCode.USER_NOT_FOUND));
}
```
위 임시로 메서드를 만들었습니다.. 근데, 기존 메서드랑 기능이 겹치는 것 같아서 협의해야할 것 같습니다. 뭐가 좋을까요? 

<br>

`그 외` 
GlobalExceptionHandler에 BusinessException 처리하는 메서드가 빠졌길래 추가했습니다. (앞으론 hotfix 브랜치에서 pr 보내겠읍니다...)

<br>
추가적으로,

> - S3로 이미지 저장하는 기능은 아직 안만들었는데 기본적인 crew 기능 구현 후 만들겠습니다!
> - 패키지 구조 정리가 필요할 것 같습니다..

<br>


## ✅ 테스트 

|크루 생성|크루명 중복
|------|---|
|<img width="766" alt="스크린샷 2025-01-10 오후 6 27 23" src="https://github.com/user-attachments/assets/43f0a762-f5f4-4df1-b889-e08ff0e9d460" />|<img width="764" alt="스크린샷 2025-01-10 오후 6 27 55" src="https://github.com/user-attachments/assets/51d45e28-6019-49c1-af2c-e2ad13401be2" />|

참고로, 지역 데이터는 db에 임시로 넣은 상태에서 테스트한 결과입니다. 


## 📌 반영 브랜치
ex) feat/#9-crew-create-> dev
