### PR TITLE
Feat/#41 search

### DIFF
--- a/src/main/java/com/example/momowas/crew/controller/CrewController.java
+++ b/src/main/java/com/example/momowas/crew/controller/CrewController.java
@@ -7,6 +7,7 @@ import com.example.momowas.crew.dto.CrewListResDto;
 import com.example.momowas.crew.dto.CrewReqDto;
 import com.example.momowas.crew.dto.CrewSpecification;
 import com.example.momowas.crew.service.CrewService;
+import com.example.momowas.crewregion.domain.CrewRegion;
 import com.example.momowas.response.CommonResponse;
 import com.example.momowas.response.ExceptionCode;
 import com.example.momowas.s3.service.S3Service;
@@ -82,7 +83,8 @@ public class CrewController {
     @GetMapping("/type")
     public List<CrewDetailResDto> searchCrewByName(@RequestParam(value = "name", required = false) String name,
                                                    @RequestParam(value = "category", required = false) Category category,
-                                                   @RequestParam(value = "age-group", required = false) Integer ageGroup) {
+                                                   @RequestParam(value = "age-group", required = false) Integer ageGroup,
+                                                   @RequestParam(value = "region", required = false) String depth1) {
         Specification<Crew> spec = (root, query, criteriaBuilder) -> null;
 
         if (name != null)
@@ -91,6 +93,8 @@ public class CrewController {
             spec = spec.and(CrewSpecification.equalCategory(category));
         if (ageGroup != null)
             spec = spec.and(CrewSpecification.equalAgeGroup(ageGroup));
+        if (depth1 != null)
+            spec = spec.and(CrewSpecification.hasRegion(depth1));
 
         return crewService.search(spec);
     }

--- a/src/main/java/com/example/momowas/crew/controller/CrewController.java
+++ b/src/main/java/com/example/momowas/crew/controller/CrewController.java
@@ -75,4 +75,9 @@ public class CrewController {
         return CommonResponse.of(ExceptionCode.SUCCESS,null);
     }
 
+    @GetMapping("/type")
+    public CrewDetailResDto searchCrewByName(@RequestParam String name) {
+        return crewService.getByName(name);
+    }
+
 }

--- a/src/main/java/com/example/momowas/crew/controller/CrewController.java
+++ b/src/main/java/com/example/momowas/crew/controller/CrewController.java
@@ -1,13 +1,17 @@
 package com.example.momowas.crew.controller;
 
+import com.example.momowas.crew.domain.Category;
+import com.example.momowas.crew.domain.Crew;
 import com.example.momowas.crew.dto.CrewDetailResDto;
 import com.example.momowas.crew.dto.CrewListResDto;
 import com.example.momowas.crew.dto.CrewReqDto;
+import com.example.momowas.crew.dto.CrewSpecification;
 import com.example.momowas.crew.service.CrewService;
 import com.example.momowas.response.CommonResponse;
 import com.example.momowas.response.ExceptionCode;
 import com.example.momowas.s3.service.S3Service;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -76,8 +80,16 @@ public class CrewController {
     }
 
     @GetMapping("/type")
-    public CrewDetailResDto searchCrewByName(@RequestParam String name) {
-        return crewService.getByName(name);
+    public List<CrewDetailResDto> searchCrewByName(@RequestParam(value = "name", required = false) String name,
+                                             @RequestParam(value = "category", required = false) Category category) {
+        Specification<Crew> spec = (root, query, criteriaBuilder) -> null;
+
+        if (name != null)
+            spec = spec.and(CrewSpecification.equalCrewName(name));
+        if (category != null)
+            spec = spec.and(CrewSpecification.equalCategory(category));
+
+        return crewService.search(spec);
     }
 
 }

--- a/src/main/java/com/example/momowas/crew/controller/CrewController.java
+++ b/src/main/java/com/example/momowas/crew/controller/CrewController.java
@@ -81,13 +81,16 @@ public class CrewController {
 
     @GetMapping("/type")
     public List<CrewDetailResDto> searchCrewByName(@RequestParam(value = "name", required = false) String name,
-                                             @RequestParam(value = "category", required = false) Category category) {
+                                                   @RequestParam(value = "category", required = false) Category category,
+                                                   @RequestParam(value = "age-group", required = false) Integer ageGroup) {
         Specification<Crew> spec = (root, query, criteriaBuilder) -> null;
 
         if (name != null)
             spec = spec.and(CrewSpecification.equalCrewName(name));
         if (category != null)
             spec = spec.and(CrewSpecification.equalCategory(category));
+        if (ageGroup != null)
+            spec = spec.and(CrewSpecification.equalAgeGroup(ageGroup));
 
         return crewService.search(spec);
     }

--- a/src/main/java/com/example/momowas/crew/dto/CrewSpecification.java
+++ b/src/main/java/com/example/momowas/crew/dto/CrewSpecification.java
@@ -3,8 +3,15 @@ package com.example.momowas.crew.dto;
 
 import com.example.momowas.crew.domain.Category;
 import com.example.momowas.crew.domain.Crew;
+import com.example.momowas.crewregion.domain.CrewRegion;
+import com.example.momowas.region.domain.Region;
 import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Subquery;
 import org.springframework.data.jpa.domain.Specification;
+
+import javax.xml.stream.Location;
 
 public class CrewSpecification {
 
@@ -36,5 +43,20 @@ public class CrewSpecification {
             );
         };
     }
+
+    public static Specification<Crew> hasRegion(String depth1) {
+        return (root, query, criteriaBuilder) -> {
+            Subquery<Long> subquery = query.subquery(Long.class);
+            Root<CrewRegion> crewRegion = subquery.from(CrewRegion.class);
+
+            Join<CrewRegion, Region> regionJoin = crewRegion.join("region");
+
+            subquery.select(crewRegion.get("crew").get("id"))
+                    .where(criteriaBuilder.equal(regionJoin.get("regionDepth1"), depth1));
+
+            return root.get("id").in(subquery);
+        };
+    }
+
 
 }

--- a/src/main/java/com/example/momowas/crew/dto/CrewSpecification.java
+++ b/src/main/java/com/example/momowas/crew/dto/CrewSpecification.java
@@ -1,0 +1,18 @@
+package com.example.momowas.crew.dto;
+
+
+import com.example.momowas.crew.domain.Category;
+import com.example.momowas.crew.domain.Crew;
+import org.springframework.data.jpa.domain.Specification;
+
+public class CrewSpecification {
+
+    public static Specification<Crew> equalCrewName(String name) {
+        return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("name"), name);
+    }
+
+    public static Specification<Crew> equalCategory(Category category) {
+        return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("category"), category);
+    }
+
+}

--- a/src/main/java/com/example/momowas/crew/dto/CrewSpecification.java
+++ b/src/main/java/com/example/momowas/crew/dto/CrewSpecification.java
@@ -3,6 +3,7 @@ package com.example.momowas.crew.dto;
 
 import com.example.momowas.crew.domain.Category;
 import com.example.momowas.crew.domain.Crew;
+import jakarta.persistence.criteria.Expression;
 import org.springframework.data.jpa.domain.Specification;
 
 public class CrewSpecification {
@@ -13,6 +14,27 @@ public class CrewSpecification {
 
     public static Specification<Crew> equalCategory(Category category) {
         return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("category"), category);
+    }
+
+    public static Specification<Crew> equalAgeGroup(Integer ageGroup) {
+        return (root, query, criteriaBuilder) -> {
+            int lowerBound = (ageGroup / 10) * 10;
+            int upperBound = lowerBound + 9;
+
+            Expression<Integer> minAge = root.get("minAge");
+            Expression<Integer> maxAge = root.get("maxAge");
+
+            //null이면 항상 만족
+            return criteriaBuilder.or(
+                    criteriaBuilder.isNull(minAge),
+                    criteriaBuilder.isNull(maxAge),
+
+                    criteriaBuilder.and(
+                            criteriaBuilder.lessThanOrEqualTo(minAge, upperBound),
+                            criteriaBuilder.greaterThanOrEqualTo(maxAge, lowerBound)
+                    )
+            );
+        };
     }
 
 }

--- a/src/main/java/com/example/momowas/crew/repository/CrewRepository.java
+++ b/src/main/java/com/example/momowas/crew/repository/CrewRepository.java
@@ -2,14 +2,10 @@ package com.example.momowas.crew.repository;
 
 import com.example.momowas.crew.domain.Crew;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-import java.util.Optional;
-
 @Repository
-public interface CrewRepository extends JpaRepository<Crew, Long> {
+public interface CrewRepository extends JpaRepository<Crew, Long>, JpaSpecificationExecutor<Crew> {
     boolean existsByName(String name);
-    Optional<Crew> findByName(String name);
-
 }

--- a/src/main/java/com/example/momowas/crew/repository/CrewRepository.java
+++ b/src/main/java/com/example/momowas/crew/repository/CrewRepository.java
@@ -4,6 +4,12 @@ import com.example.momowas.crew.domain.Crew;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Optional;
+
 @Repository
 public interface CrewRepository extends JpaRepository<Crew, Long> {
-    boolean existsByName(String name);}
+    boolean existsByName(String name);
+    Optional<Crew> findByName(String name);
+
+}

--- a/src/main/java/com/example/momowas/crew/service/CrewService.java
+++ b/src/main/java/com/example/momowas/crew/service/CrewService.java
@@ -1,5 +1,6 @@
 package com.example.momowas.crew.service;
 
+import com.example.momowas.crew.domain.Category;
 import com.example.momowas.crew.domain.Crew;
 import com.example.momowas.crew.dto.CrewDetailResDto;
 import com.example.momowas.crew.dto.CrewListResDto;
@@ -14,9 +15,11 @@ import com.example.momowas.user.domain.User;
 import com.example.momowas.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -107,12 +110,14 @@ public class CrewService {
         }
     }
 
-    public CrewDetailResDto getByName(String crewName){
-        Optional<Crew> optCrew = crewRepository.findByName(crewName);
-        if(optCrew.isEmpty()){
-            return null;
-        }
-        List<RegionDto> regionDtos = crewRegionService.findRegionByCrewId(optCrew.get().getId()); //크루 id로 지역 찾기
-        return CrewDetailResDto.of(optCrew.get(),regionDtos);
+    public List<CrewDetailResDto> search(Specification<Crew> spec){
+        List<Crew> resultCrews = crewRepository.findAll(spec);
+
+        return resultCrews.stream()
+                .map(crew -> {
+                    List<RegionDto> regionDtos = crewRegionService.findRegionByCrewId(crew.getId());
+                    return CrewDetailResDto.of(crew, regionDtos);
+                })
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/example/momowas/crew/service/CrewService.java
+++ b/src/main/java/com/example/momowas/crew/service/CrewService.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -104,5 +105,14 @@ public class CrewService {
         if (crewRepository.existsByName(crewName)) {
             throw new BusinessException(ExceptionCode.ALREADY_EXISTS_CREW);
         }
+    }
+
+    public CrewDetailResDto getByName(String crewName){
+        Optional<Crew> optCrew = crewRepository.findByName(crewName);
+        if(optCrew.isEmpty()){
+            return null;
+        }
+        List<RegionDto> regionDtos = crewRegionService.findRegionByCrewId(optCrew.get().getId()); //크루 id로 지역 찾기
+        return CrewDetailResDto.of(optCrew.get(),regionDtos);
     }
 }


### PR DESCRIPTION
## 🔗PR 타입
- [x]  feat : 기능 추가 
- [ ]  fix : 버그 수정
- [ ]  docs : 문서 관련
- [ ]  style : 스타일 변경
- [ ]  refact : 코드 리팩토링
- [ ]  build : 빌드 관련 파일 수정
- [ ]  chore : 그 외 자잘한 수정

## 🔔 변경 사항 
 JpaSpecificationExecutor로 모임명, 카테고리, 연령대, 지역 다중 조회를 구현했습니다.

연령대는 10단위로 입력하고, 크루 minAge~maxAge에 해당하면 검색 결과에 뜨도록 했습니다. 
그리고 null로 설정된 경우에는 무조건 뜨도록 했습니다..

지역별 조회는 depth1(ex. 서울특별시)과 일치하는 크루들이 뜨도록 했습니다.
> 근데 크루 지역이 crewregion엔티티에 있다보니까 어쩔 수 없이 조인을 하긴 했는데 이게 맞는지 모르겠네용.?

## ✅ 테스트 
| 모임명 조회 | 카테고리 조회 | 
|--|--|
| ![스크린샷 2025-01-23 140307](https://github.com/user-attachments/assets/30b08193-a2be-4ff3-af68-004b14290c0f) | ![스크린샷 2025-01-23 140343](https://github.com/user-attachments/assets/de0bb36d-b8c4-4271-b896-26ff7f5950da) |

| 연령대 조회 | 지역 조회 | 다중 조회}
|--|--|--|
| ![스크린샷 2025-01-23 143539](https://github.com/user-attachments/assets/afbebdbe-42e1-4d8f-95b6-907854882548) |  ![스크린샷 2025-01-23 145944](https://github.com/user-attachments/assets/09641e23-de32-4630-b29d-94359529ef6f) | ![스크린샷 2025-01-23 150236](https://github.com/user-attachments/assets/c107a939-002e-4f33-b000-da214fd7e146) |

## 📌 반영 브랜치
feat/#41-search -> dev
