### PR TITLE
Feat/#8 chat member

### DIFF
--- a/src/main/java/com/example/momowas/authorization/CrewManager.java
+++ b/src/main/java/com/example/momowas/authorization/CrewManager.java
@@ -27,4 +27,10 @@ public class CrewManager {
         CrewMember crewMember = crewMemberService.findCrewMemberByCrewAndUser(userId, crewId);
         return crewMember.getRole().equals(Role.LEADER);
     }
+
+    @Transactional(readOnly = true)
+    public Role findUserRoleInCrew(Long crewId, Long userId) {
+        CrewMember crewMember = crewMemberService.findCrewMemberByCrewAndUser(crewId, userId);
+        return crewMember.getRole();
+    }
 }

--- a/src/main/java/com/example/momowas/authorization/CrewManager.java
+++ b/src/main/java/com/example/momowas/authorization/CrewManager.java
@@ -6,11 +6,13 @@ import com.example.momowas.crewmember.service.CrewMemberService;
 import com.example.momowas.joinrequest.domain.JoinRequest;
 import com.example.momowas.joinrequest.service.JoinRequestService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class CrewManager {
 
     private final CrewMemberService crewMemberService;
@@ -30,7 +32,9 @@ public class CrewManager {
 
     @Transactional(readOnly = true)
     public Role findUserRoleInCrew(Long crewId, Long userId) {
-        CrewMember crewMember = crewMemberService.findCrewMemberByCrewAndUser(crewId, userId);
+        CrewMember crewMember = crewMemberService.findCrewMemberByCrewAndUser(userId, crewId );
+
+        log.info(String.valueOf(crewId)+ " "+String.valueOf(crewMember.getRole()));
         return crewMember.getRole();
     }
 }

--- a/src/main/java/com/example/momowas/chat/controller/ChatController.java
+++ b/src/main/java/com/example/momowas/chat/controller/ChatController.java
@@ -26,9 +26,14 @@ public class ChatController {
     @SendTo("/room/{roomId}")
     public ChatDto sendChatMessage( @DestinationVariable Long roomId, @RequestBody ChatReqDto chatReqDto, @Header("token") String token) {
         Long userId = jwtUtil.getUserIdFromToken(token);
-        log.info("UserId: {}", userId);
-        log.info("Chat Request: {}", chatReqDto);
         return chatService.createChat(roomId, chatReqDto, userId);
+    }
+
+    @MessageMapping("/room/{roomId}/enter")
+    @SendTo("/room/{roomId}")
+    public ChatDto enterChatRoomMessage( @DestinationVariable Long roomId, @Header("token") String token) {
+        Long userId = jwtUtil.getUserIdFromToken(token);
+        return chatService.enterChatRoomChat(roomId, userId);
     }
 
 }

--- a/src/main/java/com/example/momowas/chat/controller/ChatController.java
+++ b/src/main/java/com/example/momowas/chat/controller/ChatController.java
@@ -1,6 +1,6 @@
 package com.example.momowas.chat.controller;
 
-import com.example.momowas.chat.dto.ChatDto;
+import com.example.momowas.chat.dto.ChatResDto;
 import com.example.momowas.chat.dto.ChatReqDto;
 import com.example.momowas.chat.service.ChatService;
 import com.example.momowas.jwt.util.JwtUtil;
@@ -11,7 +11,6 @@ import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -24,14 +23,14 @@ public class ChatController {
 
     @MessageMapping("/room/{roomId}/message")
     @SendTo("/room/{roomId}")
-    public ChatDto sendChatMessage( @DestinationVariable Long roomId, @RequestBody ChatReqDto chatReqDto, @Header("token") String token) {
+    public ChatResDto sendChatMessage(@DestinationVariable Long roomId, @RequestBody ChatReqDto chatReqDto, @Header("token") String token) {
         Long userId = jwtUtil.getUserIdFromToken(token);
         return chatService.createChat(roomId, chatReqDto, userId);
     }
 
     @MessageMapping("/room/{roomId}/enter")
     @SendTo("/room/{roomId}")
-    public ChatDto enterChatRoomMessage( @DestinationVariable Long roomId, @Header("token") String token) {
+    public ChatResDto enterChatRoomMessage(@DestinationVariable Long roomId, @Header("token") String token) {
         Long userId = jwtUtil.getUserIdFromToken(token);
         return chatService.enterChatRoomChat(roomId, userId);
     }

--- a/src/main/java/com/example/momowas/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/example/momowas/chat/controller/ChatRoomController.java
@@ -7,6 +7,8 @@ import com.example.momowas.chat.dto.ChatDto;
 import com.example.momowas.chat.dto.ChatRoomDto;
 import com.example.momowas.chat.dto.ChatRoomReqDto;
 import com.example.momowas.chat.service.ChatService;
+import com.example.momowas.response.CommonResponse;
+import com.example.momowas.response.ExceptionCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -17,27 +19,33 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/chat")
+@RequestMapping("/chat/rooms")
 public class ChatRoomController {
     private final ChatService chatService;
 
-    @GetMapping("/room/{roomId}/history")
+    @GetMapping("/{roomId}/history")
     public List<ChatDto> chatHistory(@PathVariable Long roomId) {
         return chatService.findAllChatByRoomId(roomId);
     }
-    @GetMapping("/room/{roomId}")
+    @GetMapping("/{roomId}")
     public ChatRoomDto joinRoom(@PathVariable Long roomId) {
         return chatService.findRoomById(roomId);
     }
 
-    @PostMapping("/room")
+    @PostMapping("")
     public ChatRoomDto roomList(@RequestBody ChatRoomReqDto chatRoomReqDto) {
         return chatService.createRoom(chatRoomReqDto.getName());
     }
 
-    @GetMapping("/rooms")
+    @GetMapping("")
     public List<ChatRoomDto> roomList() {
         return chatService.findAllRoom();
+    }
+
+    @DeleteMapping("/{roomId}")
+    public CommonResponse<String> deleteChatRoom(@PathVariable Long roomId){
+        chatService.deleteChatRoom(roomId);
+        return CommonResponse.of(ExceptionCode.SUCCESS,"채팅방을 삭제했습니다");
     }
 
 }

--- a/src/main/java/com/example/momowas/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/example/momowas/chat/controller/ChatRoomController.java
@@ -1,9 +1,9 @@
 package com.example.momowas.chat.controller;
 
 
-import com.example.momowas.chat.dto.ChatDto;
-import com.example.momowas.chat.dto.ChatRoomDto;
+import com.example.momowas.chat.dto.ChatResDto;
 import com.example.momowas.chat.dto.ChatRoomReqDto;
+import com.example.momowas.chat.dto.ChatRoomResDto;
 import com.example.momowas.chat.service.ChatRoomService;
 import com.example.momowas.chat.service.ChatService;
 import com.example.momowas.jwt.util.JwtUtil;
@@ -25,24 +25,24 @@ public class ChatRoomController {
     private final JwtUtil jwtUtil;
 
     @GetMapping("/{roomId}/history")
-    public List<ChatDto> chatHistory(@PathVariable Long roomId) {
+    public List<ChatResDto> chatHistory(@PathVariable Long roomId) {
         return chatService.findAllChatByRoomId(roomId);
     }
 
     @GetMapping("/{roomId}")
-    public ChatRoomDto joinRoom(@PathVariable Long roomId) {
+    public ChatRoomResDto joinRoom(@PathVariable Long roomId) {
         return chatRoomService.findRoomById(roomId);
     }
 
     //모임 장이 채팅방 생성
     @PostMapping("")
-    public ChatRoomDto createChatRoom(HttpServletRequest request, @RequestBody ChatRoomReqDto chatRoomReqDto) {
+    public ChatRoomResDto createChatRoom(HttpServletRequest request, @RequestBody ChatRoomReqDto chatRoomReqDto) {
         Long userId = jwtUtil.getUserIdFromToken(jwtUtil.resolveToken(request).substring(7));
         return chatRoomService.createRoom(userId, chatRoomReqDto);
     }
 
     @GetMapping("")
-    public List<ChatRoomDto> roomList() {
+    public List<ChatRoomResDto> roomList() {
         return chatRoomService.findAllRoom();
     }
 

--- a/src/main/java/com/example/momowas/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/example/momowas/chat/controller/ChatRoomController.java
@@ -30,8 +30,14 @@ public class ChatRoomController {
     }
 
     @GetMapping("/{roomId}")
-    public ChatRoomResDto joinRoom(@PathVariable Long roomId) {
-        return chatRoomService.findRoomById(roomId);
+    public ChatRoomResDto findById(@PathVariable Long roomId) {
+        return chatRoomService.findById(roomId);
+    }
+
+    @GetMapping("/me")
+    public List<ChatRoomResDto> findByMe (HttpServletRequest request){
+        Long userId = jwtUtil.getUserIdFromToken(jwtUtil.resolveToken(request).substring(7));
+        return chatRoomService.findChatRoomsByMe(userId);
     }
 
     //모임 장이 채팅방 생성

--- a/src/main/java/com/example/momowas/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/example/momowas/chat/controller/ChatRoomController.java
@@ -1,14 +1,17 @@
 package com.example.momowas.chat.controller;
 
 
+import com.example.momowas.authorization.CrewManager;
 import com.example.momowas.chat.domain.Chat;
 import com.example.momowas.chat.domain.ChatRoom;
 import com.example.momowas.chat.dto.ChatDto;
 import com.example.momowas.chat.dto.ChatRoomDto;
 import com.example.momowas.chat.dto.ChatRoomReqDto;
 import com.example.momowas.chat.service.ChatService;
+import com.example.momowas.jwt.util.JwtUtil;
 import com.example.momowas.response.CommonResponse;
 import com.example.momowas.response.ExceptionCode;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -19,9 +22,11 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/chat/rooms")
+@RequestMapping("/chat-rooms")
 public class ChatRoomController {
     private final ChatService chatService;
+    private final JwtUtil jwtUtil;
+    private final CrewManager crewManager;
 
     @GetMapping("/{roomId}/history")
     public List<ChatDto> chatHistory(@PathVariable Long roomId) {
@@ -32,9 +37,13 @@ public class ChatRoomController {
         return chatService.findRoomById(roomId);
     }
 
+    //모임 장이 채팅방 생성
     @PostMapping("")
-    public ChatRoomDto roomList(@RequestBody ChatRoomReqDto chatRoomReqDto) {
-        return chatService.createRoom(chatRoomReqDto.getName());
+    public ChatRoomDto createChatRoom(HttpServletRequest request, @RequestBody ChatRoomReqDto chatRoomReqDto) {
+        Long userId = jwtUtil.getUserIdFromToken(jwtUtil.resolveToken(request).substring(7));
+        crewManager.hasCrewLeaderPermission(chatRoomReqDto.getCrewId(), userId);
+
+        return chatService.createRoom(chatRoomReqDto);
     }
 
     @GetMapping("")

--- a/src/main/java/com/example/momowas/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/example/momowas/chat/controller/ChatRoomController.java
@@ -25,8 +25,9 @@ public class ChatRoomController {
     private final JwtUtil jwtUtil;
 
     @GetMapping("/{roomId}/history")
-    public List<ChatResDto> chatHistory(@PathVariable Long roomId) {
-        return chatService.findAllChatByRoomId(roomId);
+    public List<ChatResDto> chatHistory(HttpServletRequest request, @PathVariable Long roomId) {
+        Long userId = jwtUtil.getUserIdFromToken(jwtUtil.resolveToken(request).substring(7));
+        return chatService.findAllChatByRoomId(userId, roomId);
     }
 
     @GetMapping("/{roomId}")

--- a/src/main/java/com/example/momowas/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/example/momowas/chat/controller/ChatRoomController.java
@@ -1,20 +1,16 @@
 package com.example.momowas.chat.controller;
 
 
-import com.example.momowas.authorization.CrewManager;
-import com.example.momowas.chat.domain.Chat;
-import com.example.momowas.chat.domain.ChatRoom;
 import com.example.momowas.chat.dto.ChatDto;
 import com.example.momowas.chat.dto.ChatRoomDto;
 import com.example.momowas.chat.dto.ChatRoomReqDto;
+import com.example.momowas.chat.service.ChatRoomService;
 import com.example.momowas.chat.service.ChatService;
 import com.example.momowas.jwt.util.JwtUtil;
 import com.example.momowas.response.CommonResponse;
 import com.example.momowas.response.ExceptionCode;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -25,34 +21,35 @@ import java.util.List;
 @RequestMapping("/chat-rooms")
 public class ChatRoomController {
     private final ChatService chatService;
+    private final ChatRoomService chatRoomService;
     private final JwtUtil jwtUtil;
-
 
     @GetMapping("/{roomId}/history")
     public List<ChatDto> chatHistory(@PathVariable Long roomId) {
         return chatService.findAllChatByRoomId(roomId);
     }
+
     @GetMapping("/{roomId}")
     public ChatRoomDto joinRoom(@PathVariable Long roomId) {
-        return chatService.findRoomById(roomId);
+        return chatRoomService.findRoomById(roomId);
     }
 
     //모임 장이 채팅방 생성
     @PostMapping("")
     public ChatRoomDto createChatRoom(HttpServletRequest request, @RequestBody ChatRoomReqDto chatRoomReqDto) {
         Long userId = jwtUtil.getUserIdFromToken(jwtUtil.resolveToken(request).substring(7));
-        return chatService.createRoom(userId, chatRoomReqDto);
+        return chatRoomService.createRoom(userId, chatRoomReqDto);
     }
 
     @GetMapping("")
     public List<ChatRoomDto> roomList() {
-        return chatService.findAllRoom();
+        return chatRoomService.findAllRoom();
     }
 
     @DeleteMapping("/{roomId}")
     public CommonResponse<String> deleteChatRoom(HttpServletRequest request, @PathVariable Long roomId){
         Long userId = jwtUtil.getUserIdFromToken(jwtUtil.resolveToken(request).substring(7));
-        chatService.deleteChatRoom(userId, roomId);
+        chatRoomService.deleteChatRoom(userId, roomId);
         return CommonResponse.of(ExceptionCode.SUCCESS,"채팅방을 삭제했습니다");
     }
 

--- a/src/main/java/com/example/momowas/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/example/momowas/chat/controller/ChatRoomController.java
@@ -26,7 +26,7 @@ import java.util.List;
 public class ChatRoomController {
     private final ChatService chatService;
     private final JwtUtil jwtUtil;
-    private final CrewManager crewManager;
+
 
     @GetMapping("/{roomId}/history")
     public List<ChatDto> chatHistory(@PathVariable Long roomId) {
@@ -41,9 +41,7 @@ public class ChatRoomController {
     @PostMapping("")
     public ChatRoomDto createChatRoom(HttpServletRequest request, @RequestBody ChatRoomReqDto chatRoomReqDto) {
         Long userId = jwtUtil.getUserIdFromToken(jwtUtil.resolveToken(request).substring(7));
-        crewManager.hasCrewLeaderPermission(chatRoomReqDto.getCrewId(), userId);
-
-        return chatService.createRoom(chatRoomReqDto);
+        return chatService.createRoom(userId, chatRoomReqDto);
     }
 
     @GetMapping("")
@@ -52,8 +50,9 @@ public class ChatRoomController {
     }
 
     @DeleteMapping("/{roomId}")
-    public CommonResponse<String> deleteChatRoom(@PathVariable Long roomId){
-        chatService.deleteChatRoom(roomId);
+    public CommonResponse<String> deleteChatRoom(HttpServletRequest request, @PathVariable Long roomId){
+        Long userId = jwtUtil.getUserIdFromToken(jwtUtil.resolveToken(request).substring(7));
+        chatService.deleteChatRoom(userId, roomId);
         return CommonResponse.of(ExceptionCode.SUCCESS,"채팅방을 삭제했습니다");
     }
 

--- a/src/main/java/com/example/momowas/chat/domain/ChatMember.java
+++ b/src/main/java/com/example/momowas/chat/domain/ChatMember.java
@@ -1,0 +1,35 @@
+package com.example.momowas.chat.domain;
+
+import com.example.momowas.user.domain.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ChatMember {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="chatRoom_id")
+    private ChatRoom chatRoom;
+
+    @Column(nullable = false)
+    private LocalDateTime joinedAt;
+
+    @Builder
+    public ChatMember(User user, ChatRoom chatRoom, LocalDateTime joinedAt) {
+        this.user = user;
+        this.chatRoom = chatRoom;
+        this.joinedAt = joinedAt;
+    }
+}

--- a/src/main/java/com/example/momowas/chat/domain/ChatRoom.java
+++ b/src/main/java/com/example/momowas/chat/domain/ChatRoom.java
@@ -1,10 +1,13 @@
 package com.example.momowas.chat.domain;
 
+import com.example.momowas.crewmember.domain.CrewMember;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -26,10 +29,14 @@ public class ChatRoom {
     @Column(updatable = false)
     private LocalDateTime createdAt;
 
+    @OneToMany(mappedBy = "chatRoom", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<CrewMember> chatMembers = new ArrayList<>();
+
     @Builder
-    public ChatRoom(Long crewId, String name, LocalDateTime createdAt) {
+    public ChatRoom(Long crewId, String name, LocalDateTime createdAt, List<CrewMember> chatMembers) {
         this.crewId = crewId;
         this.name = name;
         this.createdAt = createdAt;
+        this.chatMembers = chatMembers;
     }
 }

--- a/src/main/java/com/example/momowas/chat/domain/ChatRoom.java
+++ b/src/main/java/com/example/momowas/chat/domain/ChatRoom.java
@@ -16,6 +16,9 @@ public class ChatRoom {
     @Column(name = "chatRoom_id")
     private Long id;
 
+    @Column(nullable = false)
+    private Long crewId;
+
     @Column
     private String name;
 
@@ -24,7 +27,8 @@ public class ChatRoom {
     private LocalDateTime createdAt;
 
     @Builder
-    public ChatRoom(String name, LocalDateTime createdAt) {
+    public ChatRoom(Long crewId, String name, LocalDateTime createdAt) {
+        this.crewId = crewId;
         this.name = name;
         this.createdAt = createdAt;
     }

--- a/src/main/java/com/example/momowas/chat/domain/ChatRoom.java
+++ b/src/main/java/com/example/momowas/chat/domain/ChatRoom.java
@@ -30,10 +30,10 @@ public class ChatRoom {
     private LocalDateTime createdAt;
 
     @OneToMany(mappedBy = "chatRoom", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
-    private List<CrewMember> chatMembers = new ArrayList<>();
+    private List<ChatMember> chatMembers = new ArrayList<>();
 
     @Builder
-    public ChatRoom(Long crewId, String name, LocalDateTime createdAt, List<CrewMember> chatMembers) {
+    public ChatRoom(Long crewId, String name, LocalDateTime createdAt, List<ChatMember> chatMembers) {
         this.crewId = crewId;
         this.name = name;
         this.createdAt = createdAt;

--- a/src/main/java/com/example/momowas/chat/dto/ChatResDto.java
+++ b/src/main/java/com/example/momowas/chat/dto/ChatResDto.java
@@ -1,6 +1,7 @@
 package com.example.momowas.chat.dto;
 
 import com.example.momowas.chat.domain.Chat;
+import com.example.momowas.crew.domain.Role;
 import lombok.Builder;
 import lombok.Data;
 
@@ -11,23 +12,26 @@ public class ChatResDto {
     private Long roomId;
     private Long senderId;
     private String writerName;
+    private Role role;
     private String message;
     private LocalDateTime sendAt;
 
     @Builder
-    public ChatResDto(Long roomId, Long senderId, String writerName, String message, LocalDateTime sendAt) {
+    public ChatResDto(Long roomId, Long senderId, String writerName, Role role, String message, LocalDateTime sendAt) {
         this.roomId = roomId;
         this.senderId = senderId;
         this.writerName = writerName;
+        this.role = role;
         this.message = message;
         this.sendAt = sendAt;
     }
 
-    public static ChatResDto fromEntity(Chat chat){
+    public static ChatResDto fromEntity(Chat chat, Role role){
         return ChatResDto.builder()
                 .roomId(chat.getChatRoom().getId())
                 .senderId(chat.getSenderId())
                 .writerName(chat.getSenderName())
+                .role(role)
                 .message(chat.getContent())
                 .sendAt(chat.getSendAt())
                 .build();

--- a/src/main/java/com/example/momowas/chat/dto/ChatResDto.java
+++ b/src/main/java/com/example/momowas/chat/dto/ChatResDto.java
@@ -2,14 +2,12 @@ package com.example.momowas.chat.dto;
 
 import com.example.momowas.chat.domain.Chat;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.Data;
 
 import java.time.LocalDateTime;
 
-@Getter
-@Setter
-public class ChatDto {
+@Data
+public class ChatResDto {
     private Long roomId;
     private Long senderId;
     private String writerName;
@@ -17,7 +15,7 @@ public class ChatDto {
     private LocalDateTime sendAt;
 
     @Builder
-    public ChatDto(Long roomId, Long senderId,  String writerName, String message, LocalDateTime sendAt) {
+    public ChatResDto(Long roomId, Long senderId, String writerName, String message, LocalDateTime sendAt) {
         this.roomId = roomId;
         this.senderId = senderId;
         this.writerName = writerName;
@@ -25,8 +23,8 @@ public class ChatDto {
         this.sendAt = sendAt;
     }
 
-    public static ChatDto fromEntity(Chat chat){
-        return ChatDto.builder()
+    public static ChatResDto fromEntity(Chat chat){
+        return ChatResDto.builder()
                 .roomId(chat.getChatRoom().getId())
                 .senderId(chat.getSenderId())
                 .writerName(chat.getSenderName())

--- a/src/main/java/com/example/momowas/chat/dto/ChatRoomReqDto.java
+++ b/src/main/java/com/example/momowas/chat/dto/ChatRoomReqDto.java
@@ -4,5 +4,6 @@ import lombok.Data;
 
 @Data
 public class ChatRoomReqDto {
+    private Long crewId;
     private String name;
 }

--- a/src/main/java/com/example/momowas/chat/dto/ChatRoomResDto.java
+++ b/src/main/java/com/example/momowas/chat/dto/ChatRoomResDto.java
@@ -1,36 +1,32 @@
 package com.example.momowas.chat.dto;
 
-import com.example.momowas.chat.domain.Chat;
 import com.example.momowas.chat.domain.ChatRoom;
 import lombok.Builder;
 import lombok.Data;
-import lombok.Getter;
-import org.springframework.web.socket.WebSocketSession;
 
 import java.time.LocalDateTime;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
 
 @Data
-public class ChatRoomDto {
+public class ChatRoomResDto {
 
     private Long roomId;
     private String name;
+    private int chatMemberNumbers;
     private LocalDateTime createdAt;
 
     @Builder
-    public ChatRoomDto(Long roomId, String name, LocalDateTime createdAt) {
+    public ChatRoomResDto(Long roomId, String name, int chatMemberNumbers, LocalDateTime createdAt) {
         this.roomId = roomId;
         this.name = name;
+        this. chatMemberNumbers = chatMemberNumbers;
         this.createdAt = createdAt;
     }
 
-    public static ChatRoomDto fromEntity(ChatRoom chatRoom){
-        return ChatRoomDto.builder()
+    public static ChatRoomResDto fromEntity(ChatRoom chatRoom){
+        return ChatRoomResDto.builder()
                 .roomId(chatRoom.getId())
                 .name(chatRoom.getName())
+                .chatMemberNumbers(chatRoom.getChatMembers().size())
                 .createdAt(chatRoom.getCreatedAt())
                 .build();
     }

--- a/src/main/java/com/example/momowas/chat/dto/ChatRoomResDto.java
+++ b/src/main/java/com/example/momowas/chat/dto/ChatRoomResDto.java
@@ -23,10 +23,14 @@ public class ChatRoomResDto {
     }
 
     public static ChatRoomResDto fromEntity(ChatRoom chatRoom){
+        int memberNumbers = 0;
+        if(chatRoom.getChatMembers()!=null){
+            memberNumbers = chatRoom.getChatMembers().size();
+        }
         return ChatRoomResDto.builder()
                 .roomId(chatRoom.getId())
                 .name(chatRoom.getName())
-                .chatMemberNumbers(chatRoom.getChatMembers().size())
+                .chatMemberNumbers(memberNumbers)
                 .createdAt(chatRoom.getCreatedAt())
                 .build();
     }

--- a/src/main/java/com/example/momowas/chat/repository/ChatMemberRepository.java
+++ b/src/main/java/com/example/momowas/chat/repository/ChatMemberRepository.java
@@ -1,9 +1,15 @@
 package com.example.momowas.chat.repository;
 
 import com.example.momowas.chat.domain.ChatMember;
+import com.example.momowas.chat.domain.ChatRoom;
+import com.example.momowas.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface ChatMemberRepository extends JpaRepository<ChatMember, Long> {
+
+    Optional<ChatMember> findByChatRoomAndUser(ChatRoom chatRoom, User user);
 }

--- a/src/main/java/com/example/momowas/chat/repository/ChatMemberRepository.java
+++ b/src/main/java/com/example/momowas/chat/repository/ChatMemberRepository.java
@@ -6,10 +6,12 @@ import com.example.momowas.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface ChatMemberRepository extends JpaRepository<ChatMember, Long> {
 
     Optional<ChatMember> findByChatRoomAndUser(ChatRoom chatRoom, User user);
+    List<ChatMember> findByUser(User user);
 }

--- a/src/main/java/com/example/momowas/chat/repository/ChatMemberRepository.java
+++ b/src/main/java/com/example/momowas/chat/repository/ChatMemberRepository.java
@@ -14,4 +14,6 @@ public interface ChatMemberRepository extends JpaRepository<ChatMember, Long> {
 
     Optional<ChatMember> findByChatRoomAndUser(ChatRoom chatRoom, User user);
     List<ChatMember> findByUser(User user);
+
+    boolean existsByChatRoomAndUser(ChatRoom chatRoom, User user);
 }

--- a/src/main/java/com/example/momowas/chat/repository/ChatMemberRepository.java
+++ b/src/main/java/com/example/momowas/chat/repository/ChatMemberRepository.java
@@ -1,0 +1,9 @@
+package com.example.momowas.chat.repository;
+
+import com.example.momowas.chat.domain.ChatMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChatMemberRepository extends JpaRepository<ChatMember, Long> {
+}

--- a/src/main/java/com/example/momowas/chat/service/ChatMemberService.java
+++ b/src/main/java/com/example/momowas/chat/service/ChatMemberService.java
@@ -1,9 +1,36 @@
 package com.example.momowas.chat.service;
 
+import com.example.momowas.chat.domain.ChatMember;
+import com.example.momowas.chat.domain.ChatRoom;
+import com.example.momowas.chat.repository.ChatMemberRepository;
+import com.example.momowas.response.BusinessException;
+import com.example.momowas.response.ExceptionCode;
+import com.example.momowas.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class ChatMemberService {
+    private final ChatMemberRepository chatMemberRepository;
+
+    @Transactional
+    public void addParticipant(User user, ChatRoom chatRoom) {
+        boolean alreadyJoined = chatMemberRepository.findByChatRoomAndUser(chatRoom, user).isPresent();
+        if (alreadyJoined) {
+           throw new BusinessException(ExceptionCode.ALREADY_ENTER);
+        }
+        ChatMember chatMember = ChatMember.builder()
+                .chatRoom(chatRoom)
+                .user(user)
+                .joinedAt(LocalDateTime.now())
+                .build();
+        chatMemberRepository.save(chatMember);
+
+    }
+
 }

--- a/src/main/java/com/example/momowas/chat/service/ChatMemberService.java
+++ b/src/main/java/com/example/momowas/chat/service/ChatMemberService.java
@@ -1,0 +1,9 @@
+package com.example.momowas.chat.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatMemberService {
+}

--- a/src/main/java/com/example/momowas/chat/service/ChatMemberService.java
+++ b/src/main/java/com/example/momowas/chat/service/ChatMemberService.java
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -31,6 +32,13 @@ public class ChatMemberService {
                 .build();
         chatMemberRepository.save(chatMember);
 
+    }
+
+    @Transactional(readOnly = true)
+    public List<ChatRoom> findChatRoomsByUser(User user) {
+        return chatMemberRepository.findByUser(user).stream()
+                .map(ChatMember::getChatRoom)
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/com/example/momowas/chat/service/ChatMemberService.java
+++ b/src/main/java/com/example/momowas/chat/service/ChatMemberService.java
@@ -41,4 +41,9 @@ public class ChatMemberService {
                 .collect(Collectors.toList());
     }
 
+    @Transactional(readOnly = true)
+    public boolean isChatMemberExists(ChatRoom chatRoom, User user) {
+        return chatMemberRepository.existsByChatRoomAndUser(chatRoom,user);
+    }
+
 }

--- a/src/main/java/com/example/momowas/chat/service/ChatRoomService.java
+++ b/src/main/java/com/example/momowas/chat/service/ChatRoomService.java
@@ -1,0 +1,62 @@
+package com.example.momowas.chat.service;
+
+import com.example.momowas.authorization.CrewManager;
+import com.example.momowas.chat.domain.ChatRoom;
+import com.example.momowas.chat.dto.ChatRoomDto;
+import com.example.momowas.chat.dto.ChatRoomReqDto;
+import com.example.momowas.chat.repository.ChatRoomRepository;
+import com.example.momowas.response.BusinessException;
+import com.example.momowas.response.ExceptionCode;
+import com.example.momowas.user.domain.User;
+import com.example.momowas.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ChatRoomService {
+    private final ChatRoomRepository chatRoomRepository;
+    private final UserService userService;
+    private final CrewManager crewManager;
+
+
+    public List<ChatRoomDto> findAllRoom() {
+        return chatRoomRepository.findAll().stream()
+                .map(ChatRoomDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    public ChatRoom findChatRoomById(Long chatRoomId){
+        return chatRoomRepository.findById(chatRoomId).orElseThrow(()->new BusinessException(ExceptionCode.CHATROOM_NOT_FOUND));
+    }
+    public ChatRoomDto findRoomById(Long chatRoomId) {
+        ChatRoom chatRoom =  chatRoomRepository.findById(chatRoomId).orElseThrow(()->new BusinessException(ExceptionCode.CHATROOM_NOT_FOUND));
+        return ChatRoomDto.fromEntity(chatRoom);
+    }
+
+    public ChatRoomDto createRoom(Long userId, ChatRoomReqDto chatRoomReqDto) {
+        User user  = userService.findUserById(userId);
+        crewManager.hasCrewLeaderPermission(chatRoomReqDto.getCrewId(), user.getId());
+
+        ChatRoom chatRoom  = ChatRoom.builder()
+                .crewId(chatRoomReqDto.getCrewId())
+                .name(chatRoomReqDto.getName())
+                .createdAt(LocalDateTime.now())
+                .build();
+        chatRoomRepository.save(chatRoom);
+        return ChatRoomDto.fromEntity(chatRoom);
+    }
+
+    @Transactional
+    public void deleteChatRoom(Long userId, Long chatRoomId){
+        ChatRoom chatRoom =  chatRoomRepository.findById(chatRoomId).orElseThrow(()->new BusinessException(ExceptionCode.CHATROOM_NOT_FOUND));
+        crewManager.hasCrewLeaderPermission(chatRoom.getCrewId(), userId);
+
+        chatRoomRepository.delete(chatRoom);
+    }
+}

--- a/src/main/java/com/example/momowas/chat/service/ChatRoomService.java
+++ b/src/main/java/com/example/momowas/chat/service/ChatRoomService.java
@@ -1,6 +1,7 @@
 package com.example.momowas.chat.service;
 
 import com.example.momowas.authorization.CrewManager;
+import com.example.momowas.chat.domain.ChatMember;
 import com.example.momowas.chat.domain.ChatRoom;
 import com.example.momowas.chat.dto.ChatRoomDto;
 import com.example.momowas.chat.dto.ChatRoomReqDto;

--- a/src/main/java/com/example/momowas/chat/service/ChatRoomService.java
+++ b/src/main/java/com/example/momowas/chat/service/ChatRoomService.java
@@ -1,10 +1,9 @@
 package com.example.momowas.chat.service;
 
 import com.example.momowas.authorization.CrewManager;
-import com.example.momowas.chat.domain.ChatMember;
 import com.example.momowas.chat.domain.ChatRoom;
-import com.example.momowas.chat.dto.ChatRoomDto;
 import com.example.momowas.chat.dto.ChatRoomReqDto;
+import com.example.momowas.chat.dto.ChatRoomResDto;
 import com.example.momowas.chat.repository.ChatRoomRepository;
 import com.example.momowas.response.BusinessException;
 import com.example.momowas.response.ExceptionCode;
@@ -26,21 +25,21 @@ public class ChatRoomService {
     private final CrewManager crewManager;
 
 
-    public List<ChatRoomDto> findAllRoom() {
+    public List<ChatRoomResDto> findAllRoom() {
         return chatRoomRepository.findAll().stream()
-                .map(ChatRoomDto::fromEntity)
+                .map(ChatRoomResDto::fromEntity)
                 .collect(Collectors.toList());
     }
 
     public ChatRoom findChatRoomById(Long chatRoomId){
         return chatRoomRepository.findById(chatRoomId).orElseThrow(()->new BusinessException(ExceptionCode.CHATROOM_NOT_FOUND));
     }
-    public ChatRoomDto findRoomById(Long chatRoomId) {
+    public ChatRoomResDto findRoomById(Long chatRoomId) {
         ChatRoom chatRoom =  chatRoomRepository.findById(chatRoomId).orElseThrow(()->new BusinessException(ExceptionCode.CHATROOM_NOT_FOUND));
-        return ChatRoomDto.fromEntity(chatRoom);
+        return ChatRoomResDto.fromEntity(chatRoom);
     }
 
-    public ChatRoomDto createRoom(Long userId, ChatRoomReqDto chatRoomReqDto) {
+    public ChatRoomResDto createRoom(Long userId, ChatRoomReqDto chatRoomReqDto) {
         User user  = userService.findUserById(userId);
         crewManager.hasCrewLeaderPermission(chatRoomReqDto.getCrewId(), user.getId());
 
@@ -50,7 +49,7 @@ public class ChatRoomService {
                 .createdAt(LocalDateTime.now())
                 .build();
         chatRoomRepository.save(chatRoom);
-        return ChatRoomDto.fromEntity(chatRoom);
+        return ChatRoomResDto.fromEntity(chatRoom);
     }
 
     @Transactional

--- a/src/main/java/com/example/momowas/chat/service/ChatRoomService.java
+++ b/src/main/java/com/example/momowas/chat/service/ChatRoomService.java
@@ -21,6 +21,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class ChatRoomService {
     private final ChatRoomRepository chatRoomRepository;
+    private final ChatMemberService chatMemberService;
     private final UserService userService;
     private final CrewManager crewManager;
 
@@ -34,9 +35,18 @@ public class ChatRoomService {
     public ChatRoom findChatRoomById(Long chatRoomId){
         return chatRoomRepository.findById(chatRoomId).orElseThrow(()->new BusinessException(ExceptionCode.CHATROOM_NOT_FOUND));
     }
-    public ChatRoomResDto findRoomById(Long chatRoomId) {
+
+    public ChatRoomResDto findById(Long chatRoomId) {
         ChatRoom chatRoom =  chatRoomRepository.findById(chatRoomId).orElseThrow(()->new BusinessException(ExceptionCode.CHATROOM_NOT_FOUND));
         return ChatRoomResDto.fromEntity(chatRoom);
+    }
+
+    public List<ChatRoomResDto> findChatRoomsByMe(Long userId) {
+        User user = userService.findUserById(userId);
+        List<ChatRoom> chatRooms = chatMemberService.findChatRoomsByUser(user);
+        return chatRooms.stream()
+                .map(ChatRoomResDto::fromEntity)
+                .collect(Collectors.toList());
     }
 
     public ChatRoomResDto createRoom(Long userId, ChatRoomReqDto chatRoomReqDto) {

--- a/src/main/java/com/example/momowas/chat/service/ChatRoomService.java
+++ b/src/main/java/com/example/momowas/chat/service/ChatRoomService.java
@@ -41,7 +41,9 @@ public class ChatRoomService {
 
     public ChatRoomResDto createRoom(Long userId, ChatRoomReqDto chatRoomReqDto) {
         User user  = userService.findUserById(userId);
-        crewManager.hasCrewLeaderPermission(chatRoomReqDto.getCrewId(), user.getId());
+        if(!crewManager.hasCrewLeaderPermission(chatRoomReqDto.getCrewId(), user.getId())){
+            throw new BusinessException(ExceptionCode.ACCESS_DENIED);
+        }
 
         ChatRoom chatRoom  = ChatRoom.builder()
                 .crewId(chatRoomReqDto.getCrewId())
@@ -55,7 +57,9 @@ public class ChatRoomService {
     @Transactional
     public void deleteChatRoom(Long userId, Long chatRoomId){
         ChatRoom chatRoom =  chatRoomRepository.findById(chatRoomId).orElseThrow(()->new BusinessException(ExceptionCode.CHATROOM_NOT_FOUND));
-        crewManager.hasCrewLeaderPermission(chatRoom.getCrewId(), userId);
+        if(!crewManager.hasCrewLeaderPermission(chatRoom.getCrewId(),userId)){
+            throw new BusinessException(ExceptionCode.ACCESS_DENIED);
+        }
 
         chatRoomRepository.delete(chatRoom);
     }

--- a/src/main/java/com/example/momowas/chat/service/ChatService.java
+++ b/src/main/java/com/example/momowas/chat/service/ChatService.java
@@ -1,11 +1,17 @@
 package com.example.momowas.chat.service;
 
+import com.example.momowas.authorization.CrewManager;
 import com.example.momowas.chat.domain.Chat;
 import com.example.momowas.chat.domain.ChatRoom;
 import com.example.momowas.chat.domain.MessageType;
 import com.example.momowas.chat.dto.ChatResDto;
 import com.example.momowas.chat.dto.ChatReqDto;
 import com.example.momowas.chat.repository.ChatRepository;
+import com.example.momowas.crew.domain.Crew;
+import com.example.momowas.crew.domain.Role;
+import com.example.momowas.crew.service.CrewService;
+import com.example.momowas.crewmember.domain.CrewMember;
+import com.example.momowas.crewmember.service.CrewMemberService;
 import com.example.momowas.user.domain.User;
 import com.example.momowas.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +28,7 @@ public class ChatService {
     private final UserService userService;
     private final ChatRoomService chatRoomService;
     private final ChatMemberService chatMemberService;
+    private final CrewManager crewManager;
 
     public ChatResDto enterChatRoomChat(Long chatRoomId, Long userId) {
         ChatRoom chatRoom = chatRoomService.findChatRoomById(chatRoomId);
@@ -32,7 +39,7 @@ public class ChatService {
 
         Chat chat = Chat.builder()
                 .chatRoom(chatRoom)
-                .senderId(userId)
+                .senderId(user.getId())
                 .senderName(user.getNickname())
                 .type(MessageType.ENTER)
                 .content(user.getNickname() + "님이 입장하였습니다.")
@@ -40,7 +47,8 @@ public class ChatService {
                 .build();
 
         chatRepository.save(chat);
-        return ChatResDto.fromEntity(chat);
+        Role role = crewManager.findUserRoleInCrew(chatRoom.getCrewId(), chat.getSenderId());
+        return ChatResDto.fromEntity(chat, role);
     }
 
     public ChatResDto createChat(Long chatRoomId, ChatReqDto chatReqDto, Long userId) {
@@ -49,7 +57,7 @@ public class ChatService {
 
         Chat chat = Chat.builder()
                 .chatRoom(chatRoom)
-                .senderId(userId)
+                .senderId(user.getId())
                 .senderName(user.getNickname())
                 .type(MessageType.TALK)
                 .content(chatReqDto.getContent())
@@ -57,15 +65,20 @@ public class ChatService {
                 .build();
 
         chatRepository.save(chat);
-        return ChatResDto.fromEntity(chat);
+        Role role = crewManager.findUserRoleInCrew(chatRoom.getCrewId(), chat.getSenderId());
+        return ChatResDto.fromEntity(chat, role);
 
     }
 
 
     public List<ChatResDto> findAllChatByRoomId(Long chatRoomId) {
-        ChatRoom chatRoom =  chatRoomService.findChatRoomById(chatRoomId);
+        ChatRoom chatRoom = chatRoomService.findChatRoomById(chatRoomId);
+
         return chatRepository.findAllByChatRoomId(chatRoomId).stream()
-                .map(ChatResDto::fromEntity)
+                .map(chat -> {
+                    Role role = crewManager.findUserRoleInCrew(chatRoom.getCrewId(), chat.getSenderId());
+                    return ChatResDto.fromEntity(chat, role);
+                })
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/example/momowas/chat/service/ChatService.java
+++ b/src/main/java/com/example/momowas/chat/service/ChatService.java
@@ -6,6 +6,7 @@ import com.example.momowas.chat.domain.MessageType;
 import com.example.momowas.chat.dto.ChatDto;
 import com.example.momowas.chat.dto.ChatReqDto;
 import com.example.momowas.chat.dto.ChatRoomDto;
+import com.example.momowas.chat.dto.ChatRoomReqDto;
 import com.example.momowas.chat.repository.ChatRepository;
 import com.example.momowas.chat.repository.ChatRoomRepository;
 import com.example.momowas.response.BusinessException;
@@ -39,9 +40,10 @@ public class ChatService {
         return ChatRoomDto.fromEntity(chatRoom);
     }
 
-    public ChatRoomDto createRoom(String name) {
+    public ChatRoomDto createRoom(ChatRoomReqDto chatRoomReqDto) {
         ChatRoom chatRoom  = ChatRoom.builder()
-                .name(name)
+                .crewId(chatRoomReqDto.getCrewId())
+                .name(chatRoomReqDto.getName())
                 .createdAt(LocalDateTime.now())
                 .build();
         chatRoomRepository.save(chatRoom);

--- a/src/main/java/com/example/momowas/chat/service/ChatService.java
+++ b/src/main/java/com/example/momowas/chat/service/ChatService.java
@@ -15,6 +15,7 @@ import com.example.momowas.user.dto.UserDto;
 import com.example.momowas.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -71,6 +72,13 @@ public class ChatService {
         return chatRepository.findAllByChatRoomId(roomId).stream()
                 .map(ChatDto::fromEntity)
                 .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void deleteChatRoom(Long roomId){
+        ChatRoom chatRoom =  chatRoomRepository.findById(roomId).orElseThrow(()->new BusinessException(ExceptionCode.CHATROOM_NOT_FOUND));
+
+        chatRoomRepository.delete(chatRoom);
     }
 
 }

--- a/src/main/java/com/example/momowas/chat/service/ChatService.java
+++ b/src/main/java/com/example/momowas/chat/service/ChatService.java
@@ -1,23 +1,15 @@
 package com.example.momowas.chat.service;
 
-import com.example.momowas.authorization.CrewManager;
 import com.example.momowas.chat.domain.Chat;
 import com.example.momowas.chat.domain.ChatRoom;
 import com.example.momowas.chat.domain.MessageType;
 import com.example.momowas.chat.dto.ChatDto;
 import com.example.momowas.chat.dto.ChatReqDto;
-import com.example.momowas.chat.dto.ChatRoomDto;
-import com.example.momowas.chat.dto.ChatRoomReqDto;
 import com.example.momowas.chat.repository.ChatRepository;
-import com.example.momowas.chat.repository.ChatRoomRepository;
-import com.example.momowas.response.BusinessException;
-import com.example.momowas.response.ExceptionCode;
 import com.example.momowas.user.domain.User;
-import com.example.momowas.user.dto.UserDto;
 import com.example.momowas.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -26,36 +18,13 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 public class ChatService {
-    private final ChatRoomRepository chatRoomRepository;
     private final ChatRepository chatRepository;
     private final UserService userService;
-    private final CrewManager crewManager;
+    private final ChatRoomService chatRoomService;
 
-    public List<ChatRoomDto> findAllRoom() {
-        return chatRoomRepository.findAll().stream()
-                .map(ChatRoomDto::fromEntity)
-                .collect(Collectors.toList());
-    }
-
-    public ChatRoomDto findRoomById(Long id) {
-        ChatRoom chatRoom =  chatRoomRepository.findById(id).orElseThrow(()->new BusinessException(ExceptionCode.CHATROOM_NOT_FOUND));
-        return ChatRoomDto.fromEntity(chatRoom);
-    }
-
-    public ChatRoomDto createRoom(Long userId, ChatRoomReqDto chatRoomReqDto) {
-        crewManager.hasCrewLeaderPermission(chatRoomReqDto.getCrewId(), userId);
-        ChatRoom chatRoom  = ChatRoom.builder()
-                .crewId(chatRoomReqDto.getCrewId())
-                .name(chatRoomReqDto.getName())
-                .createdAt(LocalDateTime.now())
-                .build();
-        chatRoomRepository.save(chatRoom);
-        return ChatRoomDto.fromEntity(chatRoom);
-    }
 
     public ChatDto createChat(Long roomId, ChatReqDto chatReqDto, Long userId) {
-
-        ChatRoom chatRoom =  chatRoomRepository.findById(roomId).orElseThrow(()->new BusinessException(ExceptionCode.CHATROOM_NOT_FOUND));
+        ChatRoom chatRoom =  chatRoomService.findChatRoomById(roomId);
         User user  = userService.findUserById(userId);
 
         Chat chat = Chat.builder()
@@ -71,20 +40,13 @@ public class ChatService {
         return ChatDto.fromEntity(chat);
 
     }
-    public List<ChatDto> findAllChatByRoomId(Long roomId) {
-        ChatRoom chatRoom =  chatRoomRepository.findById(roomId).orElseThrow(()->new BusinessException(ExceptionCode.CHATROOM_NOT_FOUND));
-
-        return chatRepository.findAllByChatRoomId(roomId).stream()
+    public List<ChatDto> findAllChatByRoomId(Long chatRoomId) {
+        ChatRoom chatRoom =  chatRoomService.findChatRoomById(chatRoomId);
+        return chatRepository.findAllByChatRoomId(chatRoomId).stream()
                 .map(ChatDto::fromEntity)
                 .collect(Collectors.toList());
     }
 
-    @Transactional
-    public void deleteChatRoom(Long userId, Long roomId){
-        ChatRoom chatRoom =  chatRoomRepository.findById(roomId).orElseThrow(()->new BusinessException(ExceptionCode.CHATROOM_NOT_FOUND));
-        crewManager.hasCrewLeaderPermission(chatRoom.getCrewId(), userId);
 
-        chatRoomRepository.delete(chatRoom);
-    }
 
 }

--- a/src/main/java/com/example/momowas/chat/service/ChatService.java
+++ b/src/main/java/com/example/momowas/chat/service/ChatService.java
@@ -1,5 +1,6 @@
 package com.example.momowas.chat.service;
 
+import com.example.momowas.authorization.CrewManager;
 import com.example.momowas.chat.domain.Chat;
 import com.example.momowas.chat.domain.ChatRoom;
 import com.example.momowas.chat.domain.MessageType;
@@ -28,6 +29,7 @@ public class ChatService {
     private final ChatRoomRepository chatRoomRepository;
     private final ChatRepository chatRepository;
     private final UserService userService;
+    private final CrewManager crewManager;
 
     public List<ChatRoomDto> findAllRoom() {
         return chatRoomRepository.findAll().stream()
@@ -40,7 +42,8 @@ public class ChatService {
         return ChatRoomDto.fromEntity(chatRoom);
     }
 
-    public ChatRoomDto createRoom(ChatRoomReqDto chatRoomReqDto) {
+    public ChatRoomDto createRoom(Long userId, ChatRoomReqDto chatRoomReqDto) {
+        crewManager.hasCrewLeaderPermission(chatRoomReqDto.getCrewId(), userId);
         ChatRoom chatRoom  = ChatRoom.builder()
                 .crewId(chatRoomReqDto.getCrewId())
                 .name(chatRoomReqDto.getName())
@@ -77,8 +80,9 @@ public class ChatService {
     }
 
     @Transactional
-    public void deleteChatRoom(Long roomId){
+    public void deleteChatRoom(Long userId, Long roomId){
         ChatRoom chatRoom =  chatRoomRepository.findById(roomId).orElseThrow(()->new BusinessException(ExceptionCode.CHATROOM_NOT_FOUND));
+        crewManager.hasCrewLeaderPermission(chatRoom.getCrewId(), userId);
 
         chatRoomRepository.delete(chatRoom);
     }

--- a/src/main/java/com/example/momowas/chat/service/ChatService.java
+++ b/src/main/java/com/example/momowas/chat/service/ChatService.java
@@ -12,6 +12,8 @@ import com.example.momowas.crew.domain.Role;
 import com.example.momowas.crew.service.CrewService;
 import com.example.momowas.crewmember.domain.CrewMember;
 import com.example.momowas.crewmember.service.CrewMemberService;
+import com.example.momowas.response.BusinessException;
+import com.example.momowas.response.ExceptionCode;
 import com.example.momowas.user.domain.User;
 import com.example.momowas.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -71,8 +73,12 @@ public class ChatService {
     }
 
 
-    public List<ChatResDto> findAllChatByRoomId(Long chatRoomId) {
+    public List<ChatResDto> findAllChatByRoomId(Long userId, Long chatRoomId) {
         ChatRoom chatRoom = chatRoomService.findChatRoomById(chatRoomId);
+        User user = userService.findUserById(userId);
+        if(!chatMemberService.isChatMemberExists(chatRoom, user)){
+            throw new BusinessException(ExceptionCode.ACCESS_DENIED);
+        }
 
         return chatRepository.findAllByChatRoomId(chatRoomId).stream()
                 .map(chat -> {

--- a/src/main/java/com/example/momowas/chat/service/ChatService.java
+++ b/src/main/java/com/example/momowas/chat/service/ChatService.java
@@ -3,7 +3,7 @@ package com.example.momowas.chat.service;
 import com.example.momowas.chat.domain.Chat;
 import com.example.momowas.chat.domain.ChatRoom;
 import com.example.momowas.chat.domain.MessageType;
-import com.example.momowas.chat.dto.ChatDto;
+import com.example.momowas.chat.dto.ChatResDto;
 import com.example.momowas.chat.dto.ChatReqDto;
 import com.example.momowas.chat.repository.ChatRepository;
 import com.example.momowas.user.domain.User;
@@ -23,7 +23,7 @@ public class ChatService {
     private final ChatRoomService chatRoomService;
     private final ChatMemberService chatMemberService;
 
-    public ChatDto enterChatRoomChat(Long chatRoomId, Long userId) {
+    public ChatResDto enterChatRoomChat(Long chatRoomId, Long userId) {
         ChatRoom chatRoom = chatRoomService.findChatRoomById(chatRoomId);
         User user = userService.findUserById(userId);
 
@@ -40,10 +40,10 @@ public class ChatService {
                 .build();
 
         chatRepository.save(chat);
-        return ChatDto.fromEntity(chat);
+        return ChatResDto.fromEntity(chat);
     }
 
-    public ChatDto createChat(Long chatRoomId, ChatReqDto chatReqDto, Long userId) {
+    public ChatResDto createChat(Long chatRoomId, ChatReqDto chatReqDto, Long userId) {
         ChatRoom chatRoom =  chatRoomService.findChatRoomById(chatRoomId);
         User user  = userService.findUserById(userId);
 
@@ -57,15 +57,15 @@ public class ChatService {
                 .build();
 
         chatRepository.save(chat);
-        return ChatDto.fromEntity(chat);
+        return ChatResDto.fromEntity(chat);
 
     }
 
 
-    public List<ChatDto> findAllChatByRoomId(Long chatRoomId) {
+    public List<ChatResDto> findAllChatByRoomId(Long chatRoomId) {
         ChatRoom chatRoom =  chatRoomService.findChatRoomById(chatRoomId);
         return chatRepository.findAllByChatRoomId(chatRoomId).stream()
-                .map(ChatDto::fromEntity)
+                .map(ChatResDto::fromEntity)
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/example/momowas/chat/service/ChatService.java
+++ b/src/main/java/com/example/momowas/chat/service/ChatService.java
@@ -21,10 +21,30 @@ public class ChatService {
     private final ChatRepository chatRepository;
     private final UserService userService;
     private final ChatRoomService chatRoomService;
+    private final ChatMemberService chatMemberService;
 
+    public ChatDto enterChatRoomChat(Long chatRoomId, Long userId) {
+        ChatRoom chatRoom = chatRoomService.findChatRoomById(chatRoomId);
+        User user = userService.findUserById(userId);
 
-    public ChatDto createChat(Long roomId, ChatReqDto chatReqDto, Long userId) {
-        ChatRoom chatRoom =  chatRoomService.findChatRoomById(roomId);
+        // 채팅 참여자로 등록
+        chatMemberService.addParticipant(user, chatRoom);
+
+        Chat chat = Chat.builder()
+                .chatRoom(chatRoom)
+                .senderId(userId)
+                .senderName(user.getNickname())
+                .type(MessageType.ENTER)
+                .content(user.getNickname() + "님이 입장하였습니다.")
+                .sendAt(LocalDateTime.now())
+                .build();
+
+        chatRepository.save(chat);
+        return ChatDto.fromEntity(chat);
+    }
+
+    public ChatDto createChat(Long chatRoomId, ChatReqDto chatReqDto, Long userId) {
+        ChatRoom chatRoom =  chatRoomService.findChatRoomById(chatRoomId);
         User user  = userService.findUserById(userId);
 
         Chat chat = Chat.builder()
@@ -40,6 +60,8 @@ public class ChatService {
         return ChatDto.fromEntity(chat);
 
     }
+
+
     public List<ChatDto> findAllChatByRoomId(Long chatRoomId) {
         ChatRoom chatRoom =  chatRoomService.findChatRoomById(chatRoomId);
         return chatRepository.findAllByChatRoomId(chatRoomId).stream()

--- a/src/main/java/com/example/momowas/config/SecurityConfig.java
+++ b/src/main/java/com/example/momowas/config/SecurityConfig.java
@@ -52,6 +52,7 @@ public class SecurityConfig {
             "/webjars/**",
             "/error",
             "/chat/**",
+            "/index.html",
     };
     //비밀번호 암호화
     @Bean

--- a/src/main/java/com/example/momowas/config/SecurityConfig.java
+++ b/src/main/java/com/example/momowas/config/SecurityConfig.java
@@ -52,6 +52,7 @@ public class SecurityConfig {
             "/webjars/**",
             "/error",
             "/chat/**",
+            "/chat-rooms/{roomId}",
             "/index.html",
     };
     //비밀번호 암호화

--- a/src/main/java/com/example/momowas/response/ExceptionCode.java
+++ b/src/main/java/com/example/momowas/response/ExceptionCode.java
@@ -55,6 +55,7 @@ public enum ExceptionCode {
 
     //채팅방 예외
     CHATROOM_NOT_FOUND(404, "C001", "채팅방을 찾을 수 없습니다."),
+    ALREADY_ENTER(404, "C002","이미 채팅방에 입장했습니다."),
 
     //일정 예외
     SCHEDULE_NOT_FOUND(404, "SC001", "일정을 찾을 수 없습니다."),

--- a/src/main/java/com/example/momowas/schedule/service/ScheduleService.java
+++ b/src/main/java/com/example/momowas/schedule/service/ScheduleService.java
@@ -1,6 +1,5 @@
 package com.example.momowas.schedule.service;
 
-import com.example.momowas.chat.dto.ChatDto;
 import com.example.momowas.crew.domain.Crew;
 import com.example.momowas.crew.service.CrewService;
 import com.example.momowas.recommend.service.RecommendService;
@@ -11,7 +10,6 @@ import com.example.momowas.schedule.dto.ScheduleDto;
 import com.example.momowas.schedule.dto.ScheduleReqDto;
 import com.example.momowas.schedule.repository.ScheduleRepository;
 import com.example.momowas.user.domain.User;
-import com.example.momowas.user.dto.UserDto;
 import com.example.momowas.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/example/momowas/userInterests/service/UserInterestsService.java
+++ b/src/main/java/com/example/momowas/userInterests/service/UserInterestsService.java
@@ -1,6 +1,5 @@
 package com.example.momowas.userInterests.service;
 
-import com.example.momowas.chat.dto.ChatDto;
 import com.example.momowas.crew.domain.Category;
 import com.example.momowas.user.domain.User;
 import com.example.momowas.user.service.UserService;
@@ -12,7 +11,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Chat Room</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/sockjs-client/1.5.2/sockjs.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/stomp.js/2.3.3/stomp.min.js"></script>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+        }
+        #chatArea {
+            width: 80%;
+            margin: 0 auto;
+            text-align: center;
+        }
+        #messages {
+            border: 1px solid #ccc;
+            height: 300px;
+            overflow-y: auto;
+            margin-bottom: 10px;
+            padding: 10px;
+            text-align: left;
+        }
+        input, button {
+            padding: 10px;
+            margin: 5px;
+        }
+        #messageInput {
+            width: calc(100% - 120px);
+        }
+        #sendButton, #enterButton {
+            width: 100px;
+        }
+    </style>
+</head>
+<body>
+<div id="chatArea">
+    <h2>Chat Room</h2>
+
+    <label>토큰 입력:</label>
+    <input type="text" id="tokenInput" placeholder="JWT 토큰 입력">
+    <br>
+
+    <label>채팅방 ID 입력:</label>
+    <input type="number" id="roomIdInput" placeholder="Room ID 입력">
+    <br>
+
+    <button onclick="connect()">Connect</button>
+    <button onclick="disconnect()">Disconnect</button>
+    <button id="enterButton" onclick="enterChatRoom()">Enter Room</button>
+
+    <h3>Messages</h3>
+    <div id="messages"></div>
+
+    <input type="text" id="messageInput" placeholder="Enter your message">
+    <button id="sendButton">Send</button>
+</div>
+
+<script>
+    let stompClient = null;
+    let token = "";
+    let roomId = "";
+
+    function connect() {
+        token = document.getElementById("tokenInput").value;
+        roomId = document.getElementById("roomIdInput").value;
+
+        if (!token || !roomId) {
+            alert("토큰과 채팅방 ID를 입력하세요!");
+            return;
+        }
+
+        const socket = new SockJS('/stomp/chat'); // ✅ 원래 방식 유지
+        stompClient = Stomp.over(socket);
+
+        stompClient.connect({ Authorization: `Bearer ${token}` }, function (frame) {
+            console.log('Connected: ' + frame);
+
+            // Subscribe to the chat room
+            stompClient.subscribe(`/room/${roomId}`, function (message) {
+                showMessage(JSON.parse(message.body));
+            });
+
+            // 자동으로 입장 처리 가능 (원하는 경우)
+            // enterChatRoom();
+        }, function (error) {
+            console.error('WebSocket connection error:', error);
+        });
+    }
+
+    function disconnect() {
+        if (stompClient !== null) {
+            stompClient.disconnect();
+        }
+        console.log("Disconnected");
+    }
+
+    function enterChatRoom() {
+        if (!stompClient || !stompClient.connected) {
+            alert("WebSocket에 먼저 연결하세요!");
+            return;
+        }
+
+        stompClient.send(`/send/room/${roomId}/enter`, { "token": token }, {});
+        console.log("Entered chat room:", roomId);
+    }
+
+    function sendMessage() {
+        const messageInput = document.getElementById('messageInput');
+        const messageContent = messageInput.value.trim();
+
+        if (!token || !roomId) {
+            alert("토큰과 채팅방 ID를 입력하세요!");
+            return;
+        }
+
+        if (messageContent && stompClient) {
+            stompClient.send(`/send/room/${roomId}/message`,{ "token": token }, JSON.stringify({
+                content: messageContent
+            }));
+            messageInput.value = "";
+        }
+    }
+
+    function showMessage(message) {
+        const messagesDiv = document.getElementById('messages');
+        const messageElement = document.createElement('div');
+        messageElement.textContent = `[${message.sendAt}] ${message.writerName}: ${message.message}`;
+        messagesDiv.appendChild(messageElement);
+        messagesDiv.scrollTop = messagesDiv.scrollHeight;
+    }
+
+    document.getElementById('sendButton').addEventListener('click', sendMessage);
+    document.getElementById('messageInput').addEventListener('keyup', function (event) {
+        if (event.key === 'Enter') {
+            sendMessage();
+        }
+    });
+
+    window.addEventListener('beforeunload', disconnect);
+</script>
+</body>
+</html>

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -127,7 +127,7 @@
     function showMessage(message) {
         const messagesDiv = document.getElementById('messages');
         const messageElement = document.createElement('div');
-        messageElement.textContent = `[${message.sendAt}] ${message.writerName}: ${message.message}`;
+        messageElement.textContent = `[${message.sendAt}] ${message.writerName} (${message.role}): ${message.message}`;
         messagesDiv.appendChild(messageElement);
         messagesDiv.scrollTop = messagesDiv.scrollHeight;
     }


### PR DESCRIPTION
## 🔗PR 타입
- [x]  feat : 기능 추가 
- [x]  fix : 버그 수정
- [ ]  docs : 문서 관련
- [ ]  style : 스타일 변경
- [x]  refact : 코드 리팩토링
- [ ]  build : 빌드 관련 파일 수정
- [ ]  chore : 그 외 자잘한 수정

## 🔔 변경 사항 
채팅 로직 수정했습니다. 
> 조금 어설프긴한데,, 대강 되는 것 같습니다! ㅜ

`Chat`
채팅방 최초 입장 시 "000님이 입장했습니다" 멘트가 실시간을 뜨고, 중복 입장일 때 예외 처리 했습니다. 

`ChatRoom`
채팅방 생성, 삭제은 크루의 리더만 가능하게 했습니다. 
ChatMember entity 생성했습니다. 
ChatRoomResDto 에 chatMembers 숫자 추가했고, crew에서 role도 추가했습니다. (leader, member...)
현재 사용자가 가입한 채팅방 목록 조회 기능 추가했습니다. 


> 채팅방을 누가 어떻게 만들고 크루 안에 채팅방이 있는지, 그냥 아예 크루와 상관없는건지..  피그마 봤을 때 모르겠어서 
> 그냥 맘대로 규칙을 만들었습니다... 이상하거나 좋은 로직 생각나면 말해주세요!!

## ✅ 테스트 


채팅 입장 

 https://github.com/user-attachments/assets/845143f2-a1f1-4118-8962-b4c026f7e871 



| 채팅방 생성 시 leader권한 확인| 채팅 참여 user role | 
|--|--|
| ![스크린샷 2025-01-31 155251](https://github.com/user-attachments/assets/3953ac66-690a-4496-9347-5e0c11cb1989) | ![스크린샷 2025-01-31 162036](https://github.com/user-attachments/assets/b02574b9-1bb1-4a62-8a2f-f797068d3bc4) |


|내가 가입한 채팅방 | 채팅 히스토리 |
|--|--|
| ![스크린샷 2025-01-31 160731](https://github.com/user-attachments/assets/26ee3920-32d9-40f3-8006-e895306e15ed) | ![스크린샷 2025-01-31 163017](https://github.com/user-attachments/assets/032210a2-2577-47bd-b762-89152163748c) |

## 📌 반영 브랜치
feat/#8-chat-member-> dev
