### PR TITLE
Feat/#30 notice pin toggle

### DIFF
--- a/src/main/java/com/example/momowas/notice/controller/NoticeController.java
+++ b/src/main/java/com/example/momowas/notice/controller/NoticeController.java
@@ -62,4 +62,13 @@ public class NoticeController {
         noticeService.deleteNotice(noticeId);
         return CommonResponse.of(ExceptionCode.SUCCESS,null);
     }
+
+    /* 공지 상단 고정 또는 고정 되있으면 해제*/
+    @PatchMapping("/{noticeId}/pin-toggle")
+    @PreAuthorize("isAuthenticated() and @crewManager.hasCrewLeaderPermission(#crewId, #userId)") //Leader 권한만 호출 가능하도록
+    public Map<String,Object> togglePinNotice(@PathVariable Long crewId, @PathVariable Long noticeId, @AuthenticationPrincipal Long userId) {
+        Long pinnedNoticeId = noticeService.togglePinNotice(noticeId);
+        return Map.of("noticeId", pinnedNoticeId);
+    }
+
 }

--- a/src/main/java/com/example/momowas/notice/domain/Notice.java
+++ b/src/main/java/com/example/momowas/notice/domain/Notice.java
@@ -28,6 +28,8 @@ public class Notice {
 
     private String content;
 
+    private Boolean isPinned;
+
     @CreatedDate
     private LocalDateTime createdAt;
 
@@ -57,6 +59,7 @@ public class Notice {
         this.crew= Objects.requireNonNull(crew,"crew는 null이 될 수 없습니다.");
         this.crewMember= Objects.requireNonNull(crewMember,"crewMember는 null이 될 수 없습니다.");
         this.vote= vote;
+        this.isPinned=false;
     }
 
     public void updateContent(String content) {
@@ -74,5 +77,9 @@ public class Notice {
         if (this.vote != null) {
             this.vote = null;
         }
+    }
+
+    public void togglePinned() {
+        isPinned=!isPinned;
     }
 }

--- a/src/main/java/com/example/momowas/notice/dto/NoticeListResDto.java
+++ b/src/main/java/com/example/momowas/notice/dto/NoticeListResDto.java
@@ -16,7 +16,8 @@ public record NoticeListResDto(Long noticeId,
                                LocalDateTime createdAt,
                                String content,
                                @JsonInclude(JsonInclude.Include.NON_NULL)
-                               Long attendingCounts
+                               Long attendingCounts,
+                               boolean isPinned
                                ) {
     public static NoticeListResDto of(User user, CrewMember crewMember, Notice notice) {
         return new NoticeListResDto(
@@ -26,7 +27,8 @@ public record NoticeListResDto(Long noticeId,
                 user.getProfileImage(),
                 notice.getCreatedAt(),
                 notice.getContent(),
-                notice.getVote()!=null ? notice.getVote().countAttendingParticipants() : null
+                notice.getVote()!=null ? notice.getVote().countAttendingParticipants() : null,
+                notice.getIsPinned()
         );
     }
 }

--- a/src/main/java/com/example/momowas/notice/service/NoticeService.java
+++ b/src/main/java/com/example/momowas/notice/service/NoticeService.java
@@ -88,6 +88,7 @@ public class NoticeService {
         updateNoticeVote(noticeReqDto, notice);
     }
 
+    @Transactional
     private void updateNoticeVote(NoticeReqDto noticeReqDto, Notice notice) {
         VoteReqDto voteReqDto = noticeReqDto.vote();
 
@@ -108,8 +109,17 @@ public class NoticeService {
     }
 
     /* 공지 삭제 */
+    @Transactional
     public void deleteNotice(Long noticeId) {
         Notice notice = findNoticeById(noticeId);
         noticeRepository.delete(notice);
+    }
+
+    /* 공지 상단 고정 또는 고정 되있으면 해제*/
+    @Transactional
+    public Long togglePinNotice(Long noticeId) {
+        Notice notice = findNoticeById(noticeId);
+        notice.togglePinned();
+        return noticeId;
     }
 }


### PR DESCRIPTION
## 🔗PR 타입
- [x]  feat : 기능 추가 
- [ ]  fix : 버그 수정
- [ ]  docs : 문서 관련
- [ ]  style : 스타일 변경
- [ ]  refact : 코드 리팩토링
- [ ]  build : 빌드 관련 파일 수정
- [ ]  chore : 그 외 자잘한 수정

## 🔔 변경 사항 
공지 게시글 상단 고정 또는 고정되있을 경우 해제하는, 토글 기능 구현했습니다!
그리고 전체 공지 조회 api의 응답에 공지 게시글이 고정 여부를 나타내는 응답 필드도 추가했습니다.

## ✅ 테스트 
| 공지 상단 고정 또는 해제 | 공지 게시글 조회 |
|--|--|
| ![image](https://github.com/user-attachments/assets/af4a5fa2-e026-46b3-b897-01c40e1d133a) | ![image](https://github.com/user-attachments/assets/502d670e-76f6-4699-9b49-f3cbba02a23f) |


## 📌 반영 브랜치
ex) feat/#30-notice-pin-toggle-> dev
