### PR TITLE
Hotfix/#9 crew delete

### DIFF
--- a/src/main/java/com/example/momowas/crew/repository/CrewRepository.java
+++ b/src/main/java/com/example/momowas/crew/repository/CrewRepository.java
@@ -11,4 +11,5 @@ import java.util.List;
 public interface CrewRepository extends JpaRepository<Crew, Long>, JpaSpecificationExecutor<Crew> {
     boolean existsByName(String name);
     List<Crew> findByCrewMembersUserId(Long userId);
+
 }

--- a/src/main/java/com/example/momowas/crew/service/CrewService.java
+++ b/src/main/java/com/example/momowas/crew/service/CrewService.java
@@ -78,6 +78,7 @@ public class CrewService {
     @Transactional
     public void deleteCrew(Long crewId) {
         Crew crew = findCrewById(crewId);
+        crewMemberService.deleteCrewMemberByCrewId(crewId); //크루 멤버 삭제
         crewRepository.delete(crew);
     }
 

--- a/src/main/java/com/example/momowas/crewmember/controller/CrewMemberController.java
+++ b/src/main/java/com/example/momowas/crewmember/controller/CrewMemberController.java
@@ -28,10 +28,10 @@ public class CrewMemberController {
     /* 특정 크루 멤버 강제 탈퇴 */
     @DeleteMapping("/{memberId}")
     @PreAuthorize("isAuthenticated() and @crewManager.hasCrewLeaderPermission(#crewId, #userId)") //Leader 권한만 호출 가능하도록
-    public CommonResponse<String> removeCrewMember(@PathVariable Long crewId,
+    public CommonResponse<String> deleteCrewMember(@PathVariable Long crewId,
                                                    @PathVariable Long memberId,
                                                    @AuthenticationPrincipal Long userId) {
-        crewMemberService.removeCrewMember(memberId);
+        crewMemberService.deleteCrewMember(memberId);
         return CommonResponse.of(ExceptionCode.SUCCESS,null);
     }
 

--- a/src/main/java/com/example/momowas/crewmember/repository/CrewMemberRepository.java
+++ b/src/main/java/com/example/momowas/crewmember/repository/CrewMemberRepository.java
@@ -2,6 +2,9 @@ package com.example.momowas.crewmember.repository;
 
 import com.example.momowas.crewmember.domain.CrewMember;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -12,4 +15,8 @@ public interface CrewMemberRepository extends JpaRepository<CrewMember,Long> {
     Optional<CrewMember> findByCrewIdAndUserId(Long crewId, Long userId);
     boolean existsByCrewIdAndUserId(Long crewId, Long userId);
     List<CrewMember> findByCrewId(Long crewId);
+
+    @Modifying
+    @Query(value = "delete from crew_member cm where cm.crew_id = :crewId", nativeQuery = true)
+    void deleteByCrewId(@Param("crewId") Long crewId); //crew 삭제 시 crewMember를 hard delete 하기 위한 용
 }

--- a/src/main/java/com/example/momowas/crewmember/service/CrewMemberService.java
+++ b/src/main/java/com/example/momowas/crewmember/service/CrewMemberService.java
@@ -69,7 +69,7 @@ public class CrewMemberService {
 
     /* 특정 크루 멤버 강제 탈퇴 */
     @Transactional
-    public void removeCrewMember(Long crewMemberId) {
+    public void deleteCrewMember(Long crewMemberId) {
         CrewMember crewMember = findCrewMemberById(crewMemberId);
         crewMember.updateDeletedAt();
         crewMemberRepository.delete(crewMember);
@@ -89,5 +89,11 @@ public class CrewMemberService {
         CrewMember preLeader = findCrewMemberByCrewAndUser(userId, crewId);
         preLeader.updateRole(Role.MEMBER);
         postLeader.updateRole(Role.LEADER);
+    }
+
+    /* 크루 id로 크루 멤버 삭제 */
+    @Transactional
+    public void deleteCrewMemberByCrewId(Long crewId) {
+        crewMemberRepository.deleteByCrewId(crewId);
     }
 }


### PR DESCRIPTION
## 🔗PR 타입
- [ ]  feat : 기능 추가 
- [x]  fix : 버그 수정
- [ ]  docs : 문서 관련
- [ ]  style : 스타일 변경
- [ ]  refact : 코드 리팩토링
- [ ]  build : 빌드 관련 파일 수정
- [ ]  chore : 그 외 자잘한 수정

## 🔔 변경 사항 
`문제` : crew 삭제 시 crewMember가 삭제 안되고 참조 무결성 오류가 남.
`이유`: crew 삭제 시 crewMember도 삭제되도록 cascade 설정했으나 crewMember의 soft delete를 위한 설정(@SQLDelete, @Where) 때문에 hard delete가 안됨.
`해결`: crew 삭제 전 crewMember를 네이티브 쿼리릍 통해 직접 삭제하고 그 후 crew 삭제


## 📌 반영 브랜치
ex) hotfix/#9-crew-delete -> dev
