### PR TITLE
Hotfix/#9 crew delete

### DIFF
--- a/src/main/java/com/example/momowas/crew/service/CrewService.java
+++ b/src/main/java/com/example/momowas/crew/service/CrewService.java
@@ -78,7 +78,6 @@ public class CrewService {
     @Transactional
     public void deleteCrew(Long crewId) {
         Crew crew = findCrewById(crewId);
-        crewMemberService.deleteCrewMemberByCrewId(crewId); //크루 멤버 삭제
         crewRepository.delete(crew);
     }
 

--- a/src/main/java/com/example/momowas/crewmember/domain/CrewMember.java
+++ b/src/main/java/com/example/momowas/crewmember/domain/CrewMember.java
@@ -1,6 +1,8 @@
 package com.example.momowas.crewmember.domain;
 
+import com.example.momowas.archive.domain.Archive;
 import com.example.momowas.crew.domain.Crew;
+import com.example.momowas.notice.domain.Notice;
 import com.example.momowas.user.domain.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -13,14 +15,16 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @EntityListeners(AuditingEntityListener.class)
-@SQLDelete(sql = "UPDATE crew_member SET is_deleted = true WHERE id = ?")
-@Where(clause = "is_deleted = false")
+//@SQLDelete(sql = "UPDATE crew_member SET is_deleted = true WHERE id = ?")
+//@Where(clause = "is_deleted = false")
 public class CrewMember {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -40,9 +44,13 @@ public class CrewMember {
     @CreatedDate
     private LocalDateTime joinedAt;
 
-    private boolean isDeleted = false;
-
     private LocalDateTime deletedAt;
+
+    @OneToMany(mappedBy = "crewMember", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    private List<Notice> notices = new ArrayList<>();
+
+    @OneToMany(mappedBy = "crewMember", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    private List<Archive> archives = new ArrayList<>();
 
     @Builder
     private CrewMember(Crew crew, User user, Role role) {

--- a/src/main/java/com/example/momowas/crewmember/repository/CrewMemberRepository.java
+++ b/src/main/java/com/example/momowas/crewmember/repository/CrewMemberRepository.java
@@ -14,9 +14,5 @@ import java.util.Optional;
 public interface CrewMemberRepository extends JpaRepository<CrewMember,Long> {
     Optional<CrewMember> findByCrewIdAndUserId(Long crewId, Long userId);
     boolean existsByCrewIdAndUserId(Long crewId, Long userId);
-    List<CrewMember> findByCrewId(Long crewId);
-
-    @Modifying
-    @Query(value = "delete from crew_member cm where cm.crew_id = :crewId", nativeQuery = true)
-    void deleteByCrewId(@Param("crewId") Long crewId); //crew 삭제 시 crewMember를 hard delete 하기 위한 용
+    List<CrewMember> findByCrewIdAndDeletedAtIsNotNull(Long crewId);
 }

--- a/src/main/java/com/example/momowas/crewmember/service/CrewMemberService.java
+++ b/src/main/java/com/example/momowas/crewmember/service/CrewMemberService.java
@@ -63,7 +63,7 @@ public class CrewMemberService {
     /* 전체 크루 멤버 조회 */
     @Transactional(readOnly = true)
     public List<CrewMemberListResDto> getCrewMemberList(Long crewId) {
-        return crewMemberRepository.findByCrewId(crewId).stream().map(
+        return crewMemberRepository.findByCrewIdAndDeletedAtIsNotNull(crewId).stream().map(
                 CrewMemberListResDto::of).toList();
     }
 
@@ -71,8 +71,7 @@ public class CrewMemberService {
     @Transactional
     public void deleteCrewMember(Long crewMemberId) {
         CrewMember crewMember = findCrewMemberById(crewMemberId);
-        crewMember.updateDeletedAt();
-        crewMemberRepository.delete(crewMember);
+        crewMember.updateDeletedAt(); //soft delete
     }
 
     /* 크루 멤버 권한 설정 */
@@ -89,11 +88,5 @@ public class CrewMemberService {
         CrewMember preLeader = findCrewMemberByCrewAndUser(userId, crewId);
         preLeader.updateRole(Role.MEMBER);
         postLeader.updateRole(Role.LEADER);
-    }
-
-    /* 크루 id로 크루 멤버 삭제 */
-    @Transactional
-    public void deleteCrewMemberByCrewId(Long crewId) {
-        crewMemberRepository.deleteByCrewId(crewId);
     }
 }


### PR DESCRIPTION
## 🔗PR 타입
- [ ]  feat : 기능 추가 
- [x]  fix : 버그 수정
- [ ]  docs : 문서 관련
- [ ]  style : 스타일 변경
- [ ]  refact : 코드 리팩토링
- [ ]  build : 빌드 관련 파일 수정
- [ ]  chore : 그 외 자잘한 수정

## 🔔 변경 사항 
`문제`: crew member를 네이티브 쿼리로 삭제했기 때문에 연관 엔티티인 notice, archive를 cascade 설정을 해도 인식하지 못하고 삭제가 안됨.
`해결`: crew member를 수동 메서드를 통해 직접 soft delete 하고, @Where가 아닌 jpa 메서드 이름 설정을 통해 deletedAt이 null이 아닌 엔티티를 조회하도록 함.

## 📌 반영 브랜치
ex) hotfix/#9-crew-delete -> dev
