### PR TITLE
Feat/#41 elastic search

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation group: 'org.webjars', name: 'stomp-websocket', version: '2.3.3-1'
 
+    //elastic search
+    implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/momowas/config/ElasticsearchConfig.java
+++ b/src/main/java/com/example/momowas/config/ElasticsearchConfig.java
@@ -1,0 +1,26 @@
+package com.example.momowas.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.elasticsearch.client.ClientConfiguration;
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfiguration;
+
+@Configuration
+public class ElasticsearchConfig extends ElasticsearchConfiguration {
+    @Value("${spring.elasticsearch.username}")
+    private String username;
+
+    @Value("${spring.elasticsearch.password}")
+    private String password;
+
+    @Value("${spring.elasticsearch.uri}")
+    private String host;
+
+    @Override
+    public ClientConfiguration clientConfiguration() {
+        return ClientConfiguration.builder()
+                .connectedTo(host)
+                .withBasicAuth(username, password)
+                .build();
+    }
+}

--- a/src/main/java/com/example/momowas/config/ElasticsearchConfig.java
+++ b/src/main/java/com/example/momowas/config/ElasticsearchConfig.java
@@ -1,5 +1,6 @@
 package com.example.momowas.config;
 
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.elasticsearch.client.ClientConfiguration;
@@ -7,20 +8,15 @@ import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfigurat
 
 @Configuration
 public class ElasticsearchConfig extends ElasticsearchConfiguration {
-    @Value("${spring.elasticsearch.username}")
-    private String username;
 
-    @Value("${spring.elasticsearch.password}")
-    private String password;
-
-    @Value("${spring.elasticsearch.uri}")
+    @Value("${spring.elasticsearch.uris}")
     private String host;
 
     @Override
     public ClientConfiguration clientConfiguration() {
         return ClientConfiguration.builder()
                 .connectedTo(host)
-                .withBasicAuth(username, password)
                 .build();
     }
+
 }

--- a/src/main/java/com/example/momowas/config/SecurityConfig.java
+++ b/src/main/java/com/example/momowas/config/SecurityConfig.java
@@ -65,7 +65,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of("http://localhost:3000","http://13.124.54.225:8080", "https://modumoim.site","https://modumoim.site:8080"));
+        configuration.setAllowedOrigins(List.of("http://localhost:3000","http://13.124.54.225:8080", "https://modumoim.site","https://modumoim.site:8080","http://localhost:9200","https://modumoim.site:9200"));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(Collections.singletonList("*"));
         configuration.setAllowCredentials(true); // 인증 정보를 포함한 요청 허용

--- a/src/main/java/com/example/momowas/crew/controller/CrewController.java
+++ b/src/main/java/com/example/momowas/crew/controller/CrewController.java
@@ -136,12 +136,6 @@ public class CrewController {
         return crewService.search(spec);
     }
 
-    @PostMapping("/indexAll")
-    public CommonResponse<String> tmp(){
-        crewService.indexAll();
-        return CommonResponse.of(ExceptionCode.SUCCESS,"성공");
-    }
-
     @GetMapping("/me")
     public List<CrewListResDto> getCrewsByMe(HttpServletRequest request){
         Long userId = jwtUtil.getUserIdFromToken(jwtUtil.resolveToken(request).substring(7));

--- a/src/main/java/com/example/momowas/crew/controller/CrewController.java
+++ b/src/main/java/com/example/momowas/crew/controller/CrewController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -114,10 +115,17 @@ public class CrewController {
                                                    @RequestParam(value = "category", required = false) Category category,
                                                    @RequestParam(value = "age-group", required = false) Integer ageGroup,
                                                    @RequestParam(value = "region", required = false) String depth1) {
-        Specification<Crew> spec = (root, query, criteriaBuilder) -> null;
 
-        if (name != null)
-            spec = spec.and(CrewSpecification.equalCrewName(name));
+        Specification<Crew> spec = Specification.where(null);
+
+        if (name != null) {
+            List<Long> crewIds = crewService.searchName(name);
+            if (!crewIds.isEmpty()) {
+                spec = spec.and(CrewSpecification.equalCrewIdIn(crewIds));
+            } else {
+                return new ArrayList<>();
+            }
+        }
         if (category != null)
             spec = spec.and(CrewSpecification.equalCategory(category));
         if (ageGroup != null)
@@ -126,6 +134,12 @@ public class CrewController {
             spec = spec.and(CrewSpecification.hasRegion(depth1));
 
         return crewService.search(spec);
+    }
+
+    @PostMapping("/indexAll")
+    public CommonResponse<String> tmp(){
+        crewService.indexAll();
+        return CommonResponse.of(ExceptionCode.SUCCESS,"성공");
     }
 
     @GetMapping("/me")

--- a/src/main/java/com/example/momowas/crew/controller/CrewController.java
+++ b/src/main/java/com/example/momowas/crew/controller/CrewController.java
@@ -136,6 +136,12 @@ public class CrewController {
         return crewService.search(spec);
     }
 
+    @PostMapping("/indexAll")
+    public CommonResponse<String> tmp(){
+        crewService.indexAll();
+        return CommonResponse.of(ExceptionCode.SUCCESS,"성공");
+    }
+
     @GetMapping("/me")
     public List<CrewListResDto> getCrewsByMe(HttpServletRequest request){
         Long userId = jwtUtil.getUserIdFromToken(jwtUtil.resolveToken(request).substring(7));

--- a/src/main/java/com/example/momowas/crew/domain/CrewDocument.java
+++ b/src/main/java/com/example/momowas/crew/domain/CrewDocument.java
@@ -1,0 +1,25 @@
+package com.example.momowas.crew.domain;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+@Getter
+@Setter
+@Document(indexName = "crew")
+public class CrewDocument {
+
+    @Id
+    private Long id;
+
+    @Field(type = FieldType.Text, analyzer = "standard")
+    private String name;
+
+    public CrewDocument(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+}

--- a/src/main/java/com/example/momowas/crew/domain/CrewDocument.java
+++ b/src/main/java/com/example/momowas/crew/domain/CrewDocument.java
@@ -1,25 +1,31 @@
 package com.example.momowas.crew.domain;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.data.annotation.Id;
-import org.springframework.data.elasticsearch.annotations.Document;
-import org.springframework.data.elasticsearch.annotations.Field;
-import org.springframework.data.elasticsearch.annotations.FieldType;
+import org.springframework.data.elasticsearch.annotations.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @Setter
 @Document(indexName = "crew")
 public class CrewDocument {
-
     @Id
-    private Long id;
+    private String id;
+
+    @Field(type = FieldType.Long)
+    private Long crewId;
 
     @Field(type = FieldType.Text, analyzer = "standard")
     private String name;
 
-    public CrewDocument(Long id, String name) {
-        this.id = id;
+    @Builder
+    public CrewDocument(Long crewId, String name) {
+        this.crewId = crewId;
         this.name = name;
     }
 }
+

--- a/src/main/java/com/example/momowas/crew/dto/CrewSpecification.java
+++ b/src/main/java/com/example/momowas/crew/dto/CrewSpecification.java
@@ -12,11 +12,12 @@ import jakarta.persistence.criteria.Subquery;
 import org.springframework.data.jpa.domain.Specification;
 
 import javax.xml.stream.Location;
+import java.util.List;
 
 public class CrewSpecification {
 
-    public static Specification<Crew> equalCrewName(String name) {
-        return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("name"), name);
+    public static Specification<Crew> equalCrewIdIn(List<Long> ids) {
+        return (root, query, criteriaBuilder) -> root.get("id").in(ids);
     }
 
     public static Specification<Crew> equalCategory(Category category) {

--- a/src/main/java/com/example/momowas/crew/repository/CrewElasticRepository.java
+++ b/src/main/java/com/example/momowas/crew/repository/CrewElasticRepository.java
@@ -1,0 +1,9 @@
+package com.example.momowas.crew.repository;
+
+import com.example.momowas.crew.domain.CrewDocument;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+public interface CrewElasticRepository extends ElasticsearchRepository<CrewDocument, String> {
+    SearchHits<CrewDocument> findByName(String name);
+}

--- a/src/main/java/com/example/momowas/crew/repository/CrewElasticRepository.java
+++ b/src/main/java/com/example/momowas/crew/repository/CrewElasticRepository.java
@@ -3,7 +3,9 @@ package com.example.momowas.crew.repository;
 import com.example.momowas.crew.domain.CrewDocument;
 import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface CrewElasticRepository extends ElasticsearchRepository<CrewDocument, String> {
     SearchHits<CrewDocument> findByName(String name);
 }

--- a/src/main/java/com/example/momowas/crew/repository/CrewElasticRepository.java
+++ b/src/main/java/com/example/momowas/crew/repository/CrewElasticRepository.java
@@ -8,4 +8,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface CrewElasticRepository extends ElasticsearchRepository<CrewDocument, String> {
     SearchHits<CrewDocument> findByName(String name);
+    void deleteByCrewId(Long crewId);
 }

--- a/src/main/java/com/example/momowas/crew/service/CrewService.java
+++ b/src/main/java/com/example/momowas/crew/service/CrewService.java
@@ -177,6 +177,18 @@ public class CrewService {
         crewElasticRepository.save(crewDocument);
     }
 
+    public void indexAll() {
+        List<Crew> crews = crewRepository.findAll();
+
+        for (Crew crew : crews) {
+            CrewDocument crewDocument = CrewDocument.builder()
+                    .crewId(crew.getId())
+                    .name(crew.getName())
+                    .build();
+
+            crewElasticRepository.save(crewDocument);
+        }
+    }
     public List<CrewListResDto> getCrewsByMe(Long userId){
         return crewRepository.findByCrewMembersUserId(userId).stream().map(crew -> {
             List<RegionDto> regionDtos = crewRegionService.findRegionByCrewId(crew.getId());

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -70,6 +70,11 @@ spring:
           max-wait: 10000ms
         shutdown-timeout: 200ms
 
+  elasticsearch:
+    username: ${ELASTIC_USER}
+    password: ${ELASTIC_PW}
+    uris: ${ELASTIC_URI}
+
 jwt:
   secret: ${JWT_SECRET}
   redirect: ${JWT_REDIRECT_URI}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -71,8 +71,6 @@ spring:
         shutdown-timeout: 200ms
 
   elasticsearch:
-    username: ${ELASTIC_USER}
-    password: ${ELASTIC_PW}
     uris: ${ELASTIC_URI}
 
 jwt:


### PR DESCRIPTION
## 🔗PR 타입
- [x]  feat : 기능 추가 
- [ ]  fix : 버그 수정
- [ ]  docs : 문서 관련
- [ ]  style : 스타일 변경
- [x]  refact : 코드 리팩토링
- [x]  build : 빌드 관련 파일 수정
- [ ]  chore : 그 외 자잘한 수정

## 🔔 변경 사항 
elastic search로 crew name 부분 검색 가능하도록 수정했습니다.
처음에는 지금db에 있는 크루 정보를 index에 넣는 api를 실행하고, 다음부터는 크루 생성, 수정, 삭제 시 같이 반영되도록 구현했습니다.

> ex) 초코 러닝이면 초코만 입력했을 때도 초코 러닝이 결과에 나오도록

## ✅ 테스트 
| docker로 elastic search 실행 | 결과 | 다중 검색 |
|--|--|--|
| ![스크린샷 2025-03-10 204443](https://github.com/user-attachments/assets/c68da860-51b8-4aec-a01c-c76039641581) | ![스크린샷 2025-03-10 204727](https://github.com/user-attachments/assets/fdbe9767-a65f-4b6d-afda-e851c2a9227e) | ![스크린샷 2025-03-10 204739](https://github.com/user-attachments/assets/97ffa601-05ea-4d60-8117-f99f9051140a) |

## 📌 반영 브랜치
feat/#41-elastic-search -> dev
