### PR TITLE
feat: 크루별 채팅방 조회

### DIFF
--- a/src/main/java/com/example/momowas/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/example/momowas/chat/controller/ChatRoomController.java
@@ -49,7 +49,10 @@ public class ChatRoomController {
     }
 
     @GetMapping("")
-    public List<ChatRoomResDto> roomList() {
+    public List<ChatRoomResDto> roomList(@RequestParam(required = false) Long crewId) {
+        if (crewId != null) {
+            return chatRoomService.findRoomsByCrewId(crewId);
+        }
         return chatRoomService.findAllRoom();
     }
 

--- a/src/main/java/com/example/momowas/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/example/momowas/chat/repository/ChatRoomRepository.java
@@ -4,6 +4,9 @@ import com.example.momowas.chat.domain.ChatRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+    List<ChatRoom> findByCrewId(Long crewId);
 }

--- a/src/main/java/com/example/momowas/chat/service/ChatRoomService.java
+++ b/src/main/java/com/example/momowas/chat/service/ChatRoomService.java
@@ -39,7 +39,15 @@ public class ChatRoomService {
                 .collect(Collectors.toList());
     }
 
-
+    public List<ChatRoomResDto> findRoomsByCrewId(Long crewId) {
+        return chatRoomRepository.findByCrewId(crewId).stream()
+                .map(chatRoom -> ChatRoomResDto.fromEntity(
+                        chatRoom,
+                        crewMemberService.getCrewLeader(chatRoom.getCrewId()).getUser(),
+                        crewService.findCrewById(chatRoom.getCrewId())
+                ))
+                .collect(Collectors.toList());
+    }
     public ChatRoom findChatRoomById(Long chatRoomId){
         return chatRoomRepository.findById(chatRoomId).orElseThrow(()->new BusinessException(ExceptionCode.CHATROOM_NOT_FOUND));
     }


### PR DESCRIPTION
## 🔗PR 타입
- [x]  feat : 기능 추가 
- [ ]  fix : 버그 수정
- [ ]  docs : 문서 관련
- [ ]  style : 스타일 변경
- [ ]  refact : 코드 리팩토링
- [ ]  build : 빌드 관련 파일 수정
- [ ]  chore : 그 외 자잘한 수정

## 🔔 변경 사항 
크루 id에 해당하는 채팅방 목록 조회 기능 구현했습니다.
GET /chat-rooms에 crewId 파라미터로 넣으면 크루 id 별 채팅방 조회입니다. 

## ✅ 테스트 
| 전체 조회 | crew별 조회 |
|--|--|
| ![스크린샷 2025-03-17 171112](https://github.com/user-attachments/assets/56ab5a58-1b41-4326-9b42-e0f2519e7fa6) | ![스크린샷 2025-03-17 171238](https://github.com/user-attachments/assets/86ff3452-b695-4989-80a1-85156160025f) |


## 📌 반영 브랜치
feat/#8-chat-crew -> dev
