### PR TITLE
feat: 특정 크루 조회 응답 리더 정보 추가

### DIFF
--- a/src/main/java/com/example/momowas/crew/dto/CrewDetailResDto.java
+++ b/src/main/java/com/example/momowas/crew/dto/CrewDetailResDto.java
@@ -2,6 +2,7 @@ package com.example.momowas.crew.dto;
 
 import com.example.momowas.crew.domain.Category;
 import com.example.momowas.crew.domain.Crew;
+import com.example.momowas.crewmember.domain.CrewMember;
 import com.example.momowas.region.dto.RegionDto;
 import com.example.momowas.user.domain.Gender;
 
@@ -11,6 +12,8 @@ import java.util.List;
 public record CrewDetailResDto(Long crewId,
                                String name,
                                Category category,
+                               String leader,
+                               String profileImage,
                                Integer memberCount,
                                String description,
                                Integer maxMembers,
@@ -20,11 +23,13 @@ public record CrewDetailResDto(Long crewId,
                                String bannerImage,
                                List<RegionDto> regions,
                                LocalDateTime createdAt){
-    public static CrewDetailResDto of(Crew crew, List<RegionDto> regions, Integer memberCount) {
+    public static CrewDetailResDto of(Crew crew, List<RegionDto> regions, Integer memberCount, CrewMember crewLeader) {
         return new CrewDetailResDto(
                 crew.getId(),
                 crew.getName(),
                 crew.getCategory(),
+                crewLeader.getUser().getNickname(),
+                crewLeader.getUser().getProfileImage(),
                 memberCount,
                 crew.getDescription(),
                 crew.getMaxMembers(),

--- a/src/main/java/com/example/momowas/crew/service/CrewService.java
+++ b/src/main/java/com/example/momowas/crew/service/CrewService.java
@@ -82,7 +82,8 @@ public class CrewService {
         Crew crew = findCrewById(crewId);
         List<RegionDto> regionDtos = crewRegionService.findRegionByCrewId(crew.getId()); //크루 id로 지역 찾기
         Integer memberCount = crewMemberService.getCrewMemberList(crew.getId()).size(); //크루 멤버 수
-        return CrewDetailResDto.of(crew, regionDtos, memberCount);
+        CrewMember crewLeader = crewMemberService.getCrewLeader(crewId);
+        return CrewDetailResDto.of(crew, regionDtos, memberCount, crewLeader);
     }
 
     /* 특정 크루 삭제 */
@@ -150,7 +151,8 @@ public class CrewService {
                 .map(crew -> {
                     List<RegionDto> regionDtos = crewRegionService.findRegionByCrewId(crew.getId());
                     Integer memberCount = crewMemberService.getCrewMemberList(crew.getId()).size(); //크루 멤버 수
-                    return CrewDetailResDto.of(crew, regionDtos, memberCount);
+                    CrewMember crewLeader = crewMemberService.getCrewLeader(crew.getId());
+                    return CrewDetailResDto.of(crew, regionDtos, memberCount, crewLeader);
                 })
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/example/momowas/crewmember/service/CrewMemberService.java
+++ b/src/main/java/com/example/momowas/crewmember/service/CrewMemberService.java
@@ -65,6 +65,9 @@ public class CrewMemberService {
         return crewMemberRepository.findByCrewIdAndDeletedAtIsNull(crewId).stream().map(
                 CrewMemberListResDto::of).toList();
     }
+
+
+    /* 특정 크루의 리더 조회 */
     @Transactional(readOnly = true)
     public CrewMember getCrewLeader(Long crewId) {
         return crewMemberRepository.findByCrewIdAndRole(crewId, Role.LEADER).orElseThrow(() ->


### PR DESCRIPTION
## 🔗PR 타입
- [x]  feat : 기능 추가 
- [ ]  fix : 버그 수정
- [ ]  docs : 문서 관련
- [ ]  style : 스타일 변경
- [ ]  refact : 코드 리팩토링
- [ ]  build : 빌드 관련 파일 수정
- [ ]  chore : 그 외 자잘한 수정

## 🔔 변경 사항 
특정 크루 조회 응답에 리더 정보(리더 닉네임, 프로필 이미지 url) 추가했습니다.


## ✅ 테스트 
![image](https://github.com/user-attachments/assets/53749949-5cf4-4a9f-9127-c42edaab9a2a)

## 📌 반영 브랜치
ex) feat/#9-crew-detail-response -> dev
