### PR TITLE
feat: 평가 슈퍼 타입 엔티티 및 크루 평가 엔티티 생성

### DIFF
--- a/src/main/java/com/example/momowas/assessment/domain/Assessment.java
+++ b/src/main/java/com/example/momowas/assessment/domain/Assessment.java
@@ -1,0 +1,20 @@
+package com.example.momowas.assessment.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Getter
+@Inheritance(strategy = InheritanceType.JOINED)
+@DiscriminatorColumn
+public abstract class Assessment {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    protected Long id;
+
+    protected String review;
+
+    protected Double rating;
+
+}
+

--- a/src/main/java/com/example/momowas/assessment/domain/CrewAssessment.java
+++ b/src/main/java/com/example/momowas/assessment/domain/CrewAssessment.java
@@ -1,0 +1,64 @@
+package com.example.momowas.assessment.domain;
+
+import com.example.momowas.crew.domain.Crew;
+import com.example.momowas.crewmember.domain.CrewMember;
+import com.example.momowas.schedule.domain.Schedule;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.util.StringUtils;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+@Entity
+@DiscriminatorValue("CREW")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class CrewAssessment extends Assessment{
+
+    @OneToMany(mappedBy = "crewAssessment", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    private List<CrewAssessmentKeyword> crewAssessmentKeywords = new ArrayList<>();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="crew_id")
+    private Crew crew;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="crew_member_id")
+    private CrewMember crewMember;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="crew_member_id")
+    private Schedule schedule;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
+
+    @Builder
+    private CrewAssessment(String review,
+                           Double rating,
+                           Crew crew,
+                           CrewMember crewMember,
+                           Schedule schedule) {
+        if (!StringUtils.hasText(review)) {
+            throw new IllegalArgumentException("review는 null이거나 빈 문자열이 될 수 없습니다.");
+        }
+
+        this.review = review;
+        this.rating = Objects.requireNonNull(rating, "rating은 null이 될 수 없습니다.");
+        this.crew = Objects.requireNonNull(crew, "crew는 null이 될 수 없습니다.");
+        this.crewMember = Objects.requireNonNull(crewMember, "crewMember는 null이 될 수 없습니다.");
+        this.schedule = Objects.requireNonNull(schedule, "schedule는 null이 될 수 없습니다.");
+    }
+}

--- a/src/main/java/com/example/momowas/assessment/domain/CrewAssessmentKeyword.java
+++ b/src/main/java/com/example/momowas/assessment/domain/CrewAssessmentKeyword.java
@@ -1,0 +1,31 @@
+package com.example.momowas.assessment.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import java.util.Objects;
+
+/* 다대다 매핑 테이블 - 크루 평가, 키워드 */
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CrewAssessmentKeyword {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "crew_assessment_id")
+    private CrewAssessment crewAssessment;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "keyword_id")
+    private Keyword keyword;
+
+    @Builder
+    private CrewAssessmentKeyword(CrewAssessment crewAssessment, Keyword keyword) {
+        this.keyword = Objects.requireNonNull(keyword, "keyword는 null이 될 수 없습니다.");
+        this.crewAssessment = Objects.requireNonNull(crewAssessment, "crewAssessment는 null이 될 수 없습니다.");
+    }
+}

--- a/src/main/java/com/example/momowas/assessment/domain/Keyword.java
+++ b/src/main/java/com/example/momowas/assessment/domain/Keyword.java
@@ -1,0 +1,19 @@
+package com.example.momowas.assessment.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum Keyword {
+    MANAGEMENT,
+    ATMOSPHERE,
+    COMMUNICATION,
+    ENGAGEMENT,
+    USEFULNESS,
+    ENJOYMENT,
+    FRIENDSHIP,
+    EXPERTISE,
+    TIMING,
+    VENUE
+}


### PR DESCRIPTION
## 🔗PR 타입
- [x]  feat : 기능 추가 
- [ ]  fix : 버그 수정
- [ ]  docs : 문서 관련
- [ ]  style : 스타일 변경
- [ ]  refact : 코드 리팩토링
- [ ]  build : 빌드 관련 파일 수정
- [ ]  chore : 그 외 자잘한 수정

## 🔔 변경 사항 
`크루 평가`와 `멤버 평가`의 공통된 속성(리뷰, 별점)을 가지는 슈퍼 타입 엔티티를 `평가(Assessment)`로 두고,
`크루 평가(CrewAssessment)`, `멤버 평가`를 서브 타입으로 두고 조인 전략을 사용했습니다.

혹시 다른 좋은 방법이 있다면 편하게 말씀 부탁드립니다~~
그리고, Assessment라는 테이블명이 마음에 안드는데 더 좋은 네이밍이 있으면 또 추천 부탁드립니다,,


## 📌 반영 브랜치
ex) feat/#9-crew-assessment-entity -> dev
