### PR TITLE
feat: 모임 일정 다음 날 자정에 크루 리뷰 요청 알림 전송

### DIFF
--- a/src/main/java/com/example/momowas/review/dto/ScheduleReviewEventResDto.java
+++ b/src/main/java/com/example/momowas/review/dto/ScheduleReviewEventResDto.java
@@ -1,0 +1,26 @@
+package com.example.momowas.review.dto;
+
+import com.example.momowas.crew.domain.Crew;
+import com.example.momowas.schedule.domain.Schedule;
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+@Builder
+public record ScheduleReviewEventResDto(
+    Long crewId,
+    String crewName,
+    Long scheduleId,
+    String scheduleTitle,
+    LocalDate scheduleDate
+) {
+    public static ScheduleReviewEventResDto of(Crew crew, Schedule schedule) {
+        return ScheduleReviewEventResDto.builder()
+                .crewId(crew.getId())
+                .crewName(crew.getName())
+                .scheduleId(schedule.getId())
+                .scheduleTitle(schedule.getTitle())
+                .scheduleDate(schedule.getScheduleDate())
+                .build();
+    }
+}

--- a/src/main/java/com/example/momowas/review/service/CrewReviewService.java
+++ b/src/main/java/com/example/momowas/review/service/CrewReviewService.java
@@ -4,6 +4,7 @@ import com.example.momowas.crew.domain.Crew;
 import com.example.momowas.crew.service.CrewService;
 import com.example.momowas.crewmember.domain.CrewMember;
 import com.example.momowas.crewmember.service.CrewMemberService;
+import com.example.momowas.notice.domain.Notice;
 import com.example.momowas.response.BusinessException;
 import com.example.momowas.response.ExceptionCode;
 import com.example.momowas.review.domain.CrewReview;
@@ -13,10 +14,16 @@ import com.example.momowas.review.repository.CrewReviewRepository;
 import com.example.momowas.schedule.domain.Schedule;
 import com.example.momowas.schedule.dto.ScheduleInfoResDto;
 import com.example.momowas.schedule.service.ScheduleService;
+import com.example.momowas.sse.service.SseEmitterService;
+import com.example.momowas.vote.domain.Vote;
+import com.example.momowas.voteparticipant.domain.VoteParticipant;
+import com.example.momowas.voteparticipant.domain.VoteStatus;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Service
@@ -27,6 +34,7 @@ public class CrewReviewService {
     private final CrewMemberService crewMemberService;
     private final ScheduleService scheduleService;
     private final CrewReviewKeywordService crewReviewKeywordService;
+    private final SseEmitterService sseEmitterService;
 
     /* 평가 id로 크루 평가 조회 */
     @Transactional(readOnly = true)
@@ -49,7 +57,7 @@ public class CrewReviewService {
 
         CrewReview crewReview = crewReviewRepository.save(crewReviewReqDto.toEntity(crew, crewMember, schedule)); //크루 리뷰 저장
 
-        crewReviewKeywordService.createCrewReviewKeyword(crewReviewReqDto.keywords(),crewReview); //크루 리뷰-키워드 저장
+        crewReviewKeywordService.createCrewReviewKeyword(crewReviewReqDto.keywords(), crewReview); //크루 리뷰-키워드 저장
 
         return crewReview.getId();
     }
@@ -79,7 +87,7 @@ public class CrewReviewService {
 
     /* 특정 크루 평가 조회 */
     @Transactional(readOnly = true)
-    public CrewReviewDetailResDto getCrewReviewDetail(Long reviewId){
+    public CrewReviewDetailResDto getCrewReviewDetail(Long reviewId) {
         CrewReview crewReview = findCrewReviewById(reviewId);
 
         List<Keyword> keywords = crewReviewKeywordService.extractKeywordList(crewReview.getCrewReviewKeywords());
@@ -95,7 +103,7 @@ public class CrewReviewService {
 
         crewReview.updateComment(crewReviewReqDto.comment());
         crewReview.updateRating(crewReviewReqDto.rating());
-        crewReviewKeywordService.updateCrewReviewKeyword(crewReviewReqDto.keywords(),crewReview);
+        crewReviewKeywordService.updateCrewReviewKeyword(crewReviewReqDto.keywords(), crewReview);
     }
 
     /* 크루 평가 삭제 */
@@ -107,10 +115,40 @@ public class CrewReviewService {
         crewReviewRepository.deleteById(crewReview.getId());
     }
 
+    /* 모임 일정 다음 날 자정에 크루 리뷰 요청 알림 전송 */
+    @Transactional
+    @Scheduled(cron = "0 0 0 1/1 * ? *") //매일 자정마다 실행
+    //@Scheduled(cron = "0 0/1 * 1/1 * ?") //1분 주기(테스트)
+    public void sendCrewReviewNotification() {
+        LocalDate previousDay = LocalDate.now().minusDays(1);
+        List<Schedule> schedules = scheduleService.getSchedulesByDate(previousDay);
+
+        schedules.stream()
+                .forEach((schedule) -> {
+
+                    Vote vote = schedule.getNotice().getVote();
+
+                    List<VoteParticipant> positiveParticipants = vote.getVoteParticipants().stream()
+                            .filter((voteParticipant) ->
+                                    voteParticipant.getStatus() == VoteStatus.POSITIVE
+                            ).toList(); //일정 공지 투표에 '참석'에 투표한 참여자들
+
+                    // 알림 전송
+                    Crew crew = crewService.findCrewById(schedule.getCrewId());
+
+                    ScheduleReviewEventResDto payload = ScheduleReviewEventResDto.of(crew, schedule);
+
+                    for (VoteParticipant participant : positiveParticipants) {
+                        Long userId = participant.getCrewMember().getUser().getId();
+                        sseEmitterService.broadcast("review", userId, payload);
+                    }
+                });
+    }
+
     /* 사용자가 평가 작성자인지 검증 */
     private void validateWriter(Long crewId, Long userId, CrewReview crewReview) {
         CrewMember crewMember = crewMemberService.findCrewMemberByCrewAndUser(userId, crewId);
-        if(!crewReview.isWriter(crewMember)){
+        if (!crewReview.isWriter(crewMember)) {
             throw new BusinessException(ExceptionCode.ACCESS_DENIED);
         }
     }

--- a/src/main/java/com/example/momowas/sse/controller/SseController.java
+++ b/src/main/java/com/example/momowas/sse/controller/SseController.java
@@ -1,0 +1,23 @@
+package com.example.momowas.sse.controller;
+
+import com.example.momowas.sse.service.SseEmitterService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/sse")
+public class SseController {
+    private final SseEmitterService sseEmitterService;
+
+    /* 클라이언트의 이벤트 구독을 수락  */
+    @GetMapping(value = "/subscribe", produces = "text/event-stream")
+    public SseEmitter subscribe(@AuthenticationPrincipal Long userId) {
+        return sseEmitterService.subscribe(userId);
+    }
+
+}

--- a/src/main/java/com/example/momowas/sse/repository/SseEmitterRepository.java
+++ b/src/main/java/com/example/momowas/sse/repository/SseEmitterRepository.java
@@ -1,0 +1,26 @@
+package com.example.momowas.sse.repository;
+
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Repository
+public class SseEmitterRepository {
+
+    private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+    public SseEmitter findById(Long userId) {
+        return emitters.get(userId);
+    }
+
+    public SseEmitter save(Long userId, SseEmitter sseEmitter) {
+        emitters.put(userId, sseEmitter);
+        return emitters.get(userId);
+    }
+
+    public void deleteById(Long userId) {
+        emitters.remove(userId);
+    }
+}

--- a/src/main/java/com/example/momowas/sse/service/SseEmitterService.java
+++ b/src/main/java/com/example/momowas/sse/service/SseEmitterService.java
@@ -1,0 +1,51 @@
+package com.example.momowas.sse.service;
+
+import com.example.momowas.sse.repository.SseEmitterRepository;
+import com.example.momowas.review.dto.ScheduleReviewEventResDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+
+@Service
+@RequiredArgsConstructor
+public class SseEmitterService {
+    private static final Long DEFAULT_TIMEOUT = 60L * 1000 * 60;
+    private final SseEmitterRepository sseEmitterRepository;
+
+    /* 클라이언트의 이벤트 구독을 수락  */
+    public SseEmitter subscribe(Long userId) {
+        SseEmitter sseEmitter = new SseEmitter(DEFAULT_TIMEOUT);
+        sseEmitterRepository.save(userId, sseEmitter);
+
+        //SSE 연결이 정상적으로 종료됐거나, 유효 시간 내 이벤트가 전송되지 않아 타임아웃 된 경우
+        sseEmitter.onCompletion(() -> sseEmitterRepository.deleteById(userId));
+        sseEmitter.onTimeout(() -> sseEmitterRepository.deleteById(userId));
+
+        //첫 구독 시 이벤트 발생
+        sendToClient("sse",userId, "first subscribe");
+
+        return sseEmitter;
+    }
+
+    /* 이벤트를 구독한 클라이언트에게 데이터 전송 */
+    public void broadcast(String eventName, Long userId, ScheduleReviewEventResDto scheduleReviewEventResDto) {
+        sendToClient(eventName, userId, scheduleReviewEventResDto);
+    }
+
+    private void sendToClient(String eventName, Long userId, Object data) {
+        SseEmitter sseEmitter = sseEmitterRepository.findById(userId);
+        try {
+            sseEmitter.send(
+                    SseEmitter.event()
+                            .id(userId.toString())
+                            .name(eventName)
+                            .data(data)
+            );
+        } catch (IOException e) {
+            sseEmitterRepository.deleteById(userId);
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
## 🔗PR 타입
- [x]  feat : 기능 추가 
- [ ]  fix : 버그 수정
- [ ]  docs : 문서 관련
- [ ]  style : 스타일 변경
- [ ]  refact : 코드 리팩토링
- [ ]  build : 빌드 관련 파일 수정
- [ ]  chore : 그 외 자잘한 수정

## 🔔 변경 사항 
스프링 스케줄러와 sse를 이용해서 `크루 리뷰 요청 알림 기능` 구현했습니다.
모임 일정 다음 날 자정에 해당 일정 관련 공지 투표에 '참석'을 투표한 크루 멤버들에게 리뷰 요청 알림을 전송하도록 하였습니다.


## ✅ 테스트 
테스트는 매일 자정이 아닌, 1분에 한 번씩 동작하도록 설정해서 테스트했습니다 !
1분마다 크루 및 일정 정보 응답
| |
|--|
| ![image](https://github.com/user-attachments/assets/88599313-b964-4d21-b787-b2d29c73e4ce) |

## 📌 반영 브랜치
ex) feat/#9-crew-review-notification -> dev
