### PR TITLE
fix: 크루 평가 중복 예외 처리 추가

### DIFF
--- a/src/main/java/com/example/momowas/review/repository/CrewReviewRepository.java
+++ b/src/main/java/com/example/momowas/review/repository/CrewReviewRepository.java
@@ -1,6 +1,8 @@
 package com.example.momowas.review.repository;
 
+import com.example.momowas.crewmember.domain.CrewMember;
 import com.example.momowas.review.domain.CrewReview;
+import com.example.momowas.schedule.domain.Schedule;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,4 +11,6 @@ import java.util.List;
 @Repository
 public interface CrewReviewRepository extends JpaRepository<CrewReview, Long> {
     List<CrewReview> findByCrewId(Long crewId);
+
+    boolean existsByCrewMemberAndSchedule(CrewMember crewMember, Schedule schedule);
 }

--- a/src/main/java/com/example/momowas/review/service/CrewReviewService.java
+++ b/src/main/java/com/example/momowas/review/service/CrewReviewService.java
@@ -38,7 +38,6 @@ public class CrewReviewService {
     private final SseEmitterService sseEmitterService;
     private final SseEmitterRepository sseEmitterRepository;
 
-
     /* 평가 id로 크루 평가 조회 */
     @Transactional(readOnly = true)
     public CrewReview findCrewReviewById(Long crewReviewId) {
@@ -57,6 +56,11 @@ public class CrewReviewService {
         Crew crew = crewService.findCrewById(crewId);
         CrewMember crewMember = crewMemberService.findCrewMemberByCrewAndUser(userId, crewId);
         Schedule schedule = scheduleService.getScheduleByScheduleId(crewReviewReqDto.scheduleId());
+
+        //한 사람이 일정당 평가를 한 번만 가능하도록
+        if (crewReviewRepository.existsByCrewMemberAndSchedule(crewMember, schedule)) {
+            throw new BusinessException(ExceptionCode.ALREADY_WRITE_REVIEW);
+        }
 
         CrewReview crewReview = crewReviewRepository.save(crewReviewReqDto.toEntity(crew, crewMember, schedule)); //크루 리뷰 저장
 


### PR DESCRIPTION
## 🔗PR 타입
- [ ]  feat : 기능 추가 
- [x]  fix : 버그 수정
- [ ]  docs : 문서 관련
- [ ]  style : 스타일 변경
- [ ]  refact : 코드 리팩토링
- [ ]  build : 빌드 관련 파일 수정
- [ ]  chore : 그 외 자잘한 수정

## 🔔 변경 사항 
크루 멤버가 하나의 일정에 대한 크루 평가를 한 번만 할 수 있도록 중복 예외 처리를 했습니다.!

## ✅ 테스트 
| 리뷰 생성(중복 요청) |
|--|
| ![image](https://github.com/user-attachments/assets/3c86243f-eb60-4b4e-b7d3-a79244ed9c2a) |

## 📌 반영 브랜치
ex) hotfix/#9-crew-review-exception -> dev
